### PR TITLE
Async all the things

### DIFF
--- a/apollo/src/main/java/com/salesforce/apollo/Apollo.java
+++ b/apollo/src/main/java/com/salesforce/apollo/Apollo.java
@@ -25,8 +25,8 @@ import com.salesforce.apollo.avalanche.Avalanche;
 import com.salesforce.apollo.avalanche.Processor.TimedProcessor;
 import com.salesforce.apollo.comm.Router;
 import com.salesforce.apollo.fireflies.FireflyMetricsImpl;
+import com.salesforce.apollo.fireflies.Node;
 import com.salesforce.apollo.fireflies.View;
-import com.salesforce.apollo.membership.Member;
 import com.salesforce.apollo.protocols.HashKey;
 import com.salesforce.apollo.protocols.Utils;
 
@@ -73,9 +73,10 @@ public class Apollo {
         scheduler = Executors.newScheduledThreadPool(configuration.threadPool);
         IdentitySource identitySource = c.source.getIdentitySource(ApolloConfiguration.DEFAULT_CA_ALIAS,
                                                                    ApolloConfiguration.DEFAULT_IDENTITY_ALIAS);
-        HashKey id = Member.getMemberId(identitySource.identity().getCertificate());
-        communications = c.communications.getComms(metrics, id);
-        view = identitySource.createView(new HashKey(c.contextBase), communications, new FireflyMetricsImpl(metrics));
+        Node node = identitySource.getNode();
+        communications = c.communications.getComms(metrics, node);
+        view = identitySource.createView(node, new HashKey(c.contextBase), communications,
+                                         new FireflyMetricsImpl(metrics));
         seeds = identitySource.seeds();
         avalanche = new Avalanche(view, communications, c.avalanche, metrics == null ? null : new AvaMetrics(metrics),
                 processor, new MVStore.Builder().open());

--- a/apollo/src/main/java/com/salesforce/apollo/IdentitySource.java
+++ b/apollo/src/main/java/com/salesforce/apollo/IdentitySource.java
@@ -189,9 +189,8 @@ public interface IdentitySource {
         }
 
         @Override
-        public View createView(HashKey context, Router communications, FireflyMetrics metrics) {
-            FirefliesParameters parameters = new FirefliesParameters(getCA());
-            return new View(context, new Node(identity(), parameters), communications, metrics);
+        public View createView(Node node, HashKey context, Router communications, FireflyMetrics metrics) {
+            return new View(context, node, communications, metrics);
         }
     }
 
@@ -199,10 +198,15 @@ public interface IdentitySource {
     public static final String DEFAULT_IDENTITY_ALIAS = "identity";
     public static final String SEED_PREFIX            = "seed.";
 
-    default <T extends Node> View createView(HashKey context, Router communications, FireflyMetrics metrics) {
-        FirefliesParameters parameters = new FirefliesParameters(getCA());
+    default <T extends Node> View createView(Node node, HashKey context, Router communications,
+                                             FireflyMetrics metrics) {
+        return new View(context, node, communications, metrics);
+    }
 
-        return new View(context, new Node(identity(), parameters), communications, metrics);
+    default Node getNode() {
+        FirefliesParameters parameters = new FirefliesParameters(getCA());
+        Node node = new Node(identity(), parameters);
+        return node;
     }
 
     X509Certificate getCA();

--- a/avalanche/src/main/java/com/salesforce/apollo/avalanche/Avalanche.java
+++ b/avalanche/src/main/java/com/salesforce/apollo/avalanche/Avalanche.java
@@ -663,7 +663,7 @@ public class Avalanche {
         } else {
             parents = new HashSet<>();
             if (parentSample.isEmpty()) {
-                dag.sampleParents(parentSample, 100, Utils.bitStreamEntropy());
+                dag.sampleParents(parentSample, 1000, Utils.bitStreamEntropy());
             }
             if (parentSample.isEmpty()) {
                 parents.addAll(dag.finalized(Utils.bitStreamEntropy(), parameters.parentCount));

--- a/avalanche/src/main/java/com/salesforce/apollo/avalanche/Avalanche.java
+++ b/avalanche/src/main/java/com/salesforce/apollo/avalanche/Avalanche.java
@@ -240,7 +240,7 @@ public class Avalanche {
         this.node = node;
         this.context = context;
         AtomicInteger seq = new AtomicInteger();
-        this.queryExecutor = Executors.newCachedThreadPool(r -> {
+        this.queryExecutor = Executors.newFixedThreadPool(p.outstandingQueries, r -> {
             Thread t = new Thread(r, "Avalanche[" + node.getId() + "] - " + seq.incrementAndGet());
             return t;
         });

--- a/avalanche/src/main/java/com/salesforce/apollo/avalanche/AvalancheParameters.java
+++ b/avalanche/src/main/java/com/salesforce/apollo/avalanche/AvalancheParameters.java
@@ -60,7 +60,7 @@ public class AvalancheParameters {
      * Number of threads to allocate per queries - i.e. how many simultaneous
      * outbound queries we can make.
      */
-    public int            outstandingQueries       = 10;                  // Currently same as K
+    public int            outstandingQueries       = 5;
     /**
      * The number of parents we desire for new txns
      */

--- a/avalanche/src/main/java/com/salesforce/apollo/avalanche/WorkingSet.java
+++ b/avalanche/src/main/java/com/salesforce/apollo/avalanche/WorkingSet.java
@@ -424,7 +424,7 @@ public class WorkingSet {
                 while (!stack.isEmpty()) {
                     final Node node = stack.remove(stack.size() - 1);
                     List<Node> linkz = node.links();
-                    for (int i = 0; i < node.links().size(); i++) {
+                    for (int i = 0; i <linkz.size(); i++) {
                         Node e = linkz.get(i);
                         if (e.mark()) {
                             Boolean result = test.apply(e);
@@ -948,7 +948,7 @@ public class WorkingSet {
                 }
                 return isFinalized;
             }
-            return node.isStronglyPreferred();
+            return read(() -> node.isStronglyPreferred());
         }).collect(Collectors.toList());
 
     }

--- a/avalanche/src/test/java/com/salesforce/apollo/avalanche/LocalSimFunctionalTest.java
+++ b/avalanche/src/test/java/com/salesforce/apollo/avalanche/LocalSimFunctionalTest.java
@@ -7,6 +7,8 @@
 
 package com.salesforce.apollo.avalanche;
 
+import java.util.concurrent.Executors;
+
 import com.salesforce.apollo.comm.LocalRouter;
 import com.salesforce.apollo.comm.Router;
 import com.salesforce.apollo.comm.ServerConnectionCache;
@@ -23,8 +25,8 @@ public class LocalSimFunctionalTest extends AvalancheFunctionalTest {
 
     @Override
     protected Router getCommunications(Node node, boolean first) {
-        return new LocalRouter(node.getId(),
-                builder.setMetrics(new FireflyMetricsImpl(first ? node0registry : registry)));
+        return new LocalRouter(node, builder.setMetrics(new FireflyMetricsImpl(first ? node0registry : registry)),
+                Executors.newFixedThreadPool(3));
     }
 
     @Override

--- a/avalanche/src/test/java/com/salesforce/apollo/avalanche/TlsFunctionalTest.java
+++ b/avalanche/src/test/java/com/salesforce/apollo/avalanche/TlsFunctionalTest.java
@@ -7,6 +7,8 @@
 
 package com.salesforce.apollo.avalanche;
 
+import java.util.concurrent.Executors;
+
 import com.salesforce.apollo.comm.MtlsRouter;
 import com.salesforce.apollo.comm.Router;
 import com.salesforce.apollo.comm.ServerConnectionCache;
@@ -25,7 +27,7 @@ public class TlsFunctionalTest extends AvalancheFunctionalTest {
         Builder builder = ServerConnectionCache.newBuilder()
                                                .setTarget(30)
                                                .setMetrics(new FireflyMetricsImpl(first ? node0registry : registry));
-        return new MtlsRouter(builder, View.getStandardEpProvider(node));
+        return new MtlsRouter(builder, View.getStandardEpProvider(node), Executors.newFixedThreadPool(3));
     }
 
     @Override

--- a/avalanche/src/test/java/com/salesforce/apollo/avalanche/TlsFunctionalTest.java
+++ b/avalanche/src/test/java/com/salesforce/apollo/avalanche/TlsFunctionalTest.java
@@ -32,6 +32,6 @@ public class TlsFunctionalTest extends AvalancheFunctionalTest {
 
     @Override
     protected int testCardinality() {
-        return 14;
+        return 17;
     }
 }

--- a/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumClientCommunications.java
+++ b/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumClientCommunications.java
@@ -6,8 +6,6 @@
  */
 package com.salesforce.apollo.consortium.comms;
 
-import java.util.concurrent.ExecutionException;
-
 import com.google.common.util.concurrent.ListenableFuture;
 import com.salesfoce.apollo.consortium.proto.CertifiedBlock;
 import com.salesfoce.apollo.consortium.proto.CheckpointReplication;
@@ -49,18 +47,8 @@ public class ConsortiumClientCommunications implements ConsortiumService {
     }
 
     @Override
-    public CertifiedBlock checkpointSync(CheckpointSync sync) {
-        try {
-            return client.checkpointSync(sync).get();
-        } catch (InterruptedException e) {
-            throw new IllegalStateException("error communicating with: " + member, e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            }
-            throw new IllegalStateException("error communicating with: " + member, e);
-        }
+    public ListenableFuture<CertifiedBlock> checkpointSync(CheckpointSync sync) {
+        return client.checkpointSync(sync);
     }
 
     @Override

--- a/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumClientCommunications.java
+++ b/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumClientCommunications.java
@@ -8,6 +8,7 @@ package com.salesforce.apollo.consortium.comms;
 
 import java.util.concurrent.ExecutionException;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.salesfoce.apollo.consortium.proto.CertifiedBlock;
 import com.salesfoce.apollo.consortium.proto.CheckpointReplication;
 import com.salesfoce.apollo.consortium.proto.CheckpointSegments;
@@ -63,18 +64,8 @@ public class ConsortiumClientCommunications implements ConsortiumService {
     }
 
     @Override
-    public TransactionResult clientSubmit(SubmitTransaction txn) {
-        try {
-            return client.submit(txn).get();
-        } catch (InterruptedException e) {
-            throw new IllegalStateException("error communicating with: " + member, e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            }
-            throw new IllegalStateException("error communicating with: " + member, e);
-        }
+    public ListenableFuture<TransactionResult> clientSubmit(SubmitTransaction txn) {
+        return client.submit(txn);
     }
 
     @Override

--- a/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumClientCommunications.java
+++ b/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumClientCommunications.java
@@ -69,18 +69,8 @@ public class ConsortiumClientCommunications implements ConsortiumService {
     }
 
     @Override
-    public CheckpointSegments fetch(CheckpointReplication request) {
-        try {
-            return client.fetch(request).get();
-        } catch (InterruptedException e) {
-            throw new IllegalStateException("error communicating with: " + member, e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            }
-            throw new IllegalStateException("error communicating with: " + member, e);
-        }
+    public ListenableFuture<CheckpointSegments> fetch(CheckpointReplication request) {
+        return client.fetch(request);
     }
 
     public Member getMember() {

--- a/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumClientCommunications.java
+++ b/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumClientCommunications.java
@@ -78,18 +78,8 @@ public class ConsortiumClientCommunications implements ConsortiumService {
     }
 
     @Override
-    public JoinResult join(Join join) {
-        try {
-            return client.join(join).get();
-        } catch (InterruptedException e) {
-            throw new IllegalStateException("error communicating with: " + member, e);
-        } catch (ExecutionException e) {
-            Throwable cause = e.getCause();
-            if (cause instanceof RuntimeException) {
-                throw (RuntimeException) cause;
-            }
-            throw new IllegalStateException("error communicating with: " + member, e);
-        }
+    public ListenableFuture<JoinResult> join(Join join) {
+        return client.join(join);
     }
 
     public void release() {

--- a/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumService.java
+++ b/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumService.java
@@ -26,7 +26,7 @@ public interface ConsortiumService {
 
     ListenableFuture<TransactionResult> clientSubmit(SubmitTransaction request);
 
-    CheckpointSegments fetch(CheckpointReplication request);
+    ListenableFuture<CheckpointSegments> fetch(CheckpointReplication request);
 
     JoinResult join(Join join);
 

--- a/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumService.java
+++ b/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumService.java
@@ -22,7 +22,7 @@ import com.salesfoce.apollo.consortium.proto.TransactionResult;
  *
  */
 public interface ConsortiumService {
-    CertifiedBlock checkpointSync(CheckpointSync sync);
+    ListenableFuture<CertifiedBlock> checkpointSync(CheckpointSync sync);
 
     ListenableFuture<TransactionResult> clientSubmit(SubmitTransaction request);
 

--- a/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumService.java
+++ b/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumService.java
@@ -28,7 +28,7 @@ public interface ConsortiumService {
 
     ListenableFuture<CheckpointSegments> fetch(CheckpointReplication request);
 
-    JoinResult join(Join join);
+    ListenableFuture<JoinResult> join(Join join);
 
     void stopData(StopData stopData);
 }

--- a/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumService.java
+++ b/consortium/src/main/java/com/salesforce/apollo/consortium/comms/ConsortiumService.java
@@ -6,6 +6,7 @@
  */
 package com.salesforce.apollo.consortium.comms;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.salesfoce.apollo.consortium.proto.CertifiedBlock;
 import com.salesfoce.apollo.consortium.proto.CheckpointReplication;
 import com.salesfoce.apollo.consortium.proto.CheckpointSegments;
@@ -23,7 +24,7 @@ import com.salesfoce.apollo.consortium.proto.TransactionResult;
 public interface ConsortiumService {
     CertifiedBlock checkpointSync(CheckpointSync sync);
 
-    TransactionResult clientSubmit(SubmitTransaction request);
+    ListenableFuture<TransactionResult> clientSubmit(SubmitTransaction request);
 
     CheckpointSegments fetch(CheckpointReplication request);
 

--- a/consortium/src/test/java/com/salesforce/apollo/consortium/AvaConsensusTest.java
+++ b/consortium/src/test/java/com/salesforce/apollo/consortium/AvaConsensusTest.java
@@ -133,7 +133,8 @@ public class AvaConsensusTest {
 
         assertEquals(testCardinality, members.size());
 
-        members.forEach(node -> communications.put(node.getId(), new LocalRouter(node.getId(), builder)));
+        members.forEach(node -> communications.put(node.getId(),
+                                                   new LocalRouter(node, builder, Executors.newFixedThreadPool(3))));
 
         System.out.println("Test cardinality: " + testCardinality);
 

--- a/consortium/src/test/java/com/salesforce/apollo/consortium/TestConsortium.java
+++ b/consortium/src/test/java/com/salesforce/apollo/consortium/TestConsortium.java
@@ -131,7 +131,8 @@ public class TestConsortium {
 
         assertEquals(testCardinality, members.size());
 
-        members.forEach(node -> communications.put(node.getId(), new LocalRouter(node.getId(), builder)));
+        members.forEach(node -> communications.put(node.getId(),
+                                                   new LocalRouter(node, builder, Executors.newFixedThreadPool(3))));
 
     }
 

--- a/fireflies/src/main/java/com/salesforce/apollo/fireflies/View.java
+++ b/fireflies/src/main/java/com/salesforce/apollo/fireflies/View.java
@@ -41,6 +41,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Timer;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.salesfoce.apollo.proto.AccusationGossip;
 import com.salesfoce.apollo.proto.AccusationGossip.Builder;
 import com.salesfoce.apollo.proto.CertificateGossip;
@@ -179,8 +181,10 @@ public class View {
         /**
          * Perform ye one ring round of gossip. Gossip is performed per ring, requiring
          * 2 * tolerance + 1 gossip rounds across all rings.
+         * 
+         * @param completion TODO
          */
-        public void gossip() {
+        public void gossip(Runnable completion) {
             if (!started.get()) {
                 return;
             }
@@ -191,13 +195,7 @@ public class View {
                 return;
             }
             log.trace("gossiping with {} on {}", link.getMember(), lastRing);
-            try {
-                View.this.gossip(lastRing, link);
-            } catch (Exception e) {
-                log.debug("Partial round of gossip with {}, ring {}", link.getMember(), lastRing, e);
-            } finally {
-                link.release();
-            }
+            View.this.gossip(lastRing, link, completion);
         }
 
         public boolean isStarted() {
@@ -885,74 +883,82 @@ public class View {
     /**
      * Gossip with the member
      * 
-     * @param ring - the index of the gossip ring the gossip is originating from in
-     *             this view
-     * @param link - the outbound communications to the paired member
+     * @param ring       - the index of the gossip ring the gossip is originating
+     *                   from in this view
+     * @param link       - the outbound communications to the paired member
+     * @param completion
      * @throws Exception
      */
-    boolean gossip(int ring, FfClientCommunications link) throws Exception {
+    void gossip(int ring, FfClientCommunications link, Runnable completion) {
+        Participant member = link.getMember();
         Signed signedNote = node.getSignedNote();
         if (signedNote == null) {
-            return true;
+            return;
         }
         Digests outbound = commonDigests();
-        Gossip gossip;
-        try {
-            gossip = link.gossip(context.getId(), signedNote, ring, outbound);
-        } catch (Throwable e) {
-            log.debug("Exception gossiping with {}", link.getMember(), e);
-            return false;
-        }
-        if (log.isTraceEnabled()) {
-            log.trace("inbound: redirect: {} updates: certs: {}, notes: {}, accusations: {} ", gossip.getRedirect(),
-                      gossip.getCertificates().getUpdatesCount(), gossip.getNotes().getUpdatesCount(),
-                      gossip.getAccusations().getUpdatesCount());
-        }
-        if (gossip.getRedirect()) {
-            if (gossip.getCertificates().getUpdatesCount() != 1 && gossip.getNotes().getUpdatesCount() != 1) {
-                log.warn("Redirect response from {} on ring {} did not contain redirect member certificate and note",
-                         link.getMember(), ring);
-                return false;
-            }
-            if (gossip.getAccusations().getUpdatesCount() > 0) {
-                // Reset our epoch to whatever the group has recorded for this recovering node
-                long max = gossip.getAccusations()
-                                 .getUpdatesList()
-                                 .stream()
-                                 .map(signed -> new Accusation(signed.getContent().toByteArray(),
-                                         signed.getSignature().toByteArray()))
-                                 .mapToLong(a -> a.getEpoch())
-                                 .max()
-                                 .orElse(-1);
-                node.nextNote(max + 1);
-            }
-            CertWithHash certificate = certificateFrom(gossip.getCertificates().getUpdates(0));
-            if (certificate != null) {
-                link.release();
-                add(certificate);
-                Signed signed = gossip.getNotes().getUpdates(0);
-                Note note = new Note(signed.getContent().toByteArray(), signed.getSignature().toByteArray());
-                add(note);
-                gossip.getAccusations()
-                      .getUpdatesList()
-                      .forEach(s -> add(new Accusation(s.getContent().toByteArray(), s.getSignature().toByteArray())));
-                log.debug("Redirected from {} to {} on ring {}", link.getMember(), note.getId(), ring);
-                return false;
-            } else {
-                log.warn("Redirect certificate from {} on ring {} is null", link.getMember(), ring);
-                return false;
-            }
-        }
-        Update update = response(gossip);
-        if (!isEmpty(update)) {
+        ListenableFuture<Gossip> futureSailor = link.gossip(context.getId(), signedNote, ring, outbound);
+        futureSailor.addListener(() -> {
+            Gossip gossip;
             try {
-                link.update(context.getId(), ring, update);
+                gossip = futureSailor.get();
             } catch (Throwable e) {
-                log.debug("Exception updating {}", link.getMember(), e);
-                return false;
+                log.debug("Exception gossiping with {}", link.getMember(), e);
+                link.release();
+                completion.run();
+                return;
             }
+
+            if (log.isTraceEnabled()) {
+                log.trace("inbound: redirect: {} updates: certs: {}, notes: {}, accusations: {} ", gossip.getRedirect(),
+                          gossip.getCertificates().getUpdatesCount(), gossip.getNotes().getUpdatesCount(),
+                          gossip.getAccusations().getUpdatesCount());
+            }
+            if (gossip.getRedirect()) {
+                redirect(member, gossip, ring);
+                link.release();
+                completion.run();
+            } else {
+                Update update = response(gossip);
+                if (!isEmpty(update)) {
+                    link.update(context.getId(), ring, update);
+                }
+                link.release();
+                completion.run();
+            }
+        }, fjPool);
+    }
+
+    private void redirect(Participant member, Gossip gossip, int ring) {
+        if (gossip.getCertificates().getUpdatesCount() != 1 && gossip.getNotes().getUpdatesCount() != 1) {
+            log.warn("Redirect response from {} on ring {} did not contain redirect member certificate and note",
+                     member, ring);
+            return;
         }
-        return true;
+        if (gossip.getAccusations().getUpdatesCount() > 0) {
+            // Reset our epoch to whatever the group has recorded for this recovering node
+            long max = gossip.getAccusations()
+                             .getUpdatesList()
+                             .stream()
+                             .map(signed -> new Accusation(signed.getContent().toByteArray(),
+                                     signed.getSignature().toByteArray()))
+                             .mapToLong(a -> a.getEpoch())
+                             .max()
+                             .orElse(-1);
+            node.nextNote(max + 1);
+        }
+        CertWithHash certificate = certificateFrom(gossip.getCertificates().getUpdates(0));
+        if (certificate != null) {
+            add(certificate);
+            Signed signed = gossip.getNotes().getUpdates(0);
+            Note note = new Note(signed.getContent().toByteArray(), signed.getSignature().toByteArray());
+            add(note);
+            gossip.getAccusations()
+                  .getUpdatesList()
+                  .forEach(s -> add(new Accusation(s.getContent().toByteArray(), s.getSignature().toByteArray())));
+            log.debug("Redirected from {} to {} on ring {}", member, note.getId(), ring);
+        } else {
+            log.warn("Redirect certificate from {} on ring {} is null", member, ring);
+        }
     }
 
     /**
@@ -1057,45 +1063,43 @@ public class View {
      * @param d
      */
     void oneRound(Duration d, ScheduledExecutorService scheduler) {
-        com.codahale.metrics.Timer.Context timer = null;
-        if (metrics != null) {
-            timer = metrics.gossipRoundDuration().time();
-        }
+        Timer.Context timer = metrics != null ? metrics.gossipRoundDuration().time() : null;
+        round.incrementAndGet();
         try {
-            round.incrementAndGet();
-            try {
-                service.gossip();
-            } catch (Throwable e) {
-                log.error("unexpected error during gossip round", e);
-            }
-            try {
-                service.monitor();
-            } catch (Throwable e) {
-                log.error("unexpected error during monitor round", e);
-            }
-            maintainTimers();
-        } finally {
-            if (timer != null) {
-                timer.stop();
-            }
-        }
-
-        roundListeners.forEach(l -> {
-            fjPool.execute(() -> {
+            service.gossip(() -> {
                 try {
-                    l.run();
-                } catch (Throwable e) {
-                    log.error("error sending round() to listener: " + l, e);
+                    try {
+                        service.monitor();
+                    } catch (Throwable e) {
+                        log.error("unexpected error during monitor round", e);
+                    }
+                    maintainTimers();
+                } finally {
+                    if (timer != null) {
+                        timer.stop();
+                    }
                 }
+
+                roundListeners.forEach(l -> {
+                    fjPool.execute(() -> {
+                        try {
+                            l.run();
+                        } catch (Throwable e) {
+                            log.error("error sending round() to listener: " + l, e);
+                        }
+                    });
+                });
+                scheduler.schedule(() -> fjPool.execute(() -> {
+                    try {
+                        oneRound(d, scheduler);
+                    } catch (Throwable e) {
+                        log.error("unexpected error during gossip round", e);
+                    }
+                }), d.toMillis(), TimeUnit.MILLISECONDS);
             });
-        });
-        scheduler.schedule(() -> fjPool.execute(() -> {
-            try {
-                oneRound(d, scheduler);
-            } catch (Throwable e) {
-                log.error("unexpected error during gossip round", e);
-            }
-        }), d.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (Throwable e) {
+            log.error("unexpected error during gossip round", e);
+        }
     }
 
     /**

--- a/fireflies/src/main/java/com/salesforce/apollo/fireflies/View.java
+++ b/fireflies/src/main/java/com/salesforce/apollo/fireflies/View.java
@@ -191,37 +191,12 @@ public class View {
                 return;
             }
             log.trace("gossiping with {} on {}", link.getMember(), lastRing);
-            boolean success;
             try {
-                success = View.this.gossip(lastRing, link);
+                View.this.gossip(lastRing, link);
             } catch (Exception e) {
                 log.debug("Partial round of gossip with {}, ring {}", link.getMember(), lastRing, e);
-                return;
             } finally {
                 link.release();
-            }
-            if (!success) {
-                try {
-                    link = linkFor(lastRing);
-                    if (link == null) {
-                        log.debug("No link for ring {}", lastRing);
-                        return;
-                    }
-                    success = View.this.gossip(lastRing, link);
-                } catch (Exception e) {
-                    log.debug("Partial round of gossip with {}, ring {}", link.getMember(), lastRing);
-                    return;
-                } finally {
-                    if (link != null) {
-                        link.release();
-                    }
-                }
-                if (!success) {
-                    log.trace("Partial redirect round of gossip with {}, ring {} not redirecting further",
-                              link.getMember(), lastRing);
-                } else {
-                    log.trace("Successful redirect round of gossip with {}, ring {}", link.getMember(), lastRing);
-                }
             }
         }
 
@@ -789,8 +764,8 @@ public class View {
      * @param seed
      */
     void addSeed(Participant seed) {
-        seed.setNote(new Note(seed.getId(), -1,
-                Node.createInitialMask(getParameters().toleranceLevel, Utils.entropy()), node.forSigning()));
+        seed.setNote(new Note(seed.getId(), -1, Node.createInitialMask(getParameters().toleranceLevel, Utils.entropy()),
+                node.forSigning()));
         context.add(seed);
         context.activate(seed);
     }

--- a/fireflies/src/test/java/com/salesforce/apollo/fireflies/FunctionalTest.java
+++ b/fireflies/src/test/java/com/salesforce/apollo/fireflies/FunctionalTest.java
@@ -95,8 +95,8 @@ public class FunctionalTest {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(10);
 
         views = members.parallelStream().map(node -> {
-            Router comms = new LocalRouter(node.getId(),
-                    ServerConnectionCache.newBuilder().setTarget(30).setMetrics(metrics));
+            Router comms = new LocalRouter(node, ServerConnectionCache.newBuilder().setTarget(30).setMetrics(metrics),
+                    Executors.newFixedThreadPool(3));
             comms.start();
             communications.add(comms);
             return new View(HashKey.ORIGIN, node, comms, metrics);

--- a/fireflies/src/test/java/com/salesforce/apollo/fireflies/FunctionalTest.java
+++ b/fireflies/src/test/java/com/salesforce/apollo/fireflies/FunctionalTest.java
@@ -106,7 +106,8 @@ public class FunctionalTest {
 
         for (int j = 0; j < 20; j++) {
             for (int i = 0; i < parameters.rings + 2; i++) {
-                views.forEach(view -> view.getService().gossip());
+                views.forEach(view -> view.getService().gossip(() -> {
+                }));
             }
         }
 

--- a/fireflies/src/test/java/com/salesforce/apollo/fireflies/LargeTest.java
+++ b/fireflies/src/test/java/com/salesforce/apollo/fireflies/LargeTest.java
@@ -160,8 +160,9 @@ public class LargeTest {
         views = members.stream().map(node -> {
             FireflyMetricsImpl fireflyMetricsImpl = new FireflyMetricsImpl(
                     frist.getAndSet(false) ? node0Registry : registry);
-            LocalRouter comms = new LocalRouter(node.getId(),
-                    ServerConnectionCache.newBuilder().setTarget(2).setMetrics(fireflyMetricsImpl));
+            LocalRouter comms = new LocalRouter(node,
+                    ServerConnectionCache.newBuilder().setTarget(2).setMetrics(fireflyMetricsImpl),
+                    Executors.newFixedThreadPool(3));
             communications.add(comms);
             return new View(HashKey.ORIGIN, node, comms, fireflyMetricsImpl);
         }).collect(Collectors.toList());

--- a/fireflies/src/test/java/com/salesforce/apollo/fireflies/MtlsTest.java
+++ b/fireflies/src/test/java/com/salesforce/apollo/fireflies/MtlsTest.java
@@ -109,7 +109,7 @@ public class MtlsTest {
             FireflyMetricsImpl metrics = new FireflyMetricsImpl(frist.getAndSet(false) ? node0Registry : registry);
             EndpointProvider ep = getStandardEpProvider(node);
             builder.setMetrics(metrics);
-            MtlsRouter comms = new MtlsRouter(builder, ep);
+            MtlsRouter comms = new MtlsRouter(builder, ep, Executors.newFixedThreadPool(3));
             communications.add(comms);
             return new View(HashKey.ORIGIN, node, comms, metrics);
         }).collect(Collectors.toList());

--- a/fireflies/src/test/java/com/salesforce/apollo/fireflies/SuccessorTest.java
+++ b/fireflies/src/test/java/com/salesforce/apollo/fireflies/SuccessorTest.java
@@ -134,14 +134,15 @@ public class SuccessorTest {
             System.out.println("ring: " + ring + " successor: " + successor);
             assertEquals(successor, views.get(successor).getRing(ring).successor(test.getNode(), m -> !m.isFailed()));
             assertTrue(successor.isLive());
-            test.getService().gossip();
+            test.getService().gossip(() -> {
+            });
 
             ring = (ring + 1) % test.getRings().size();
             successor = test.getRing(ring).successor(test.getNode(), m -> !m.isFailed());
             System.out.println("ring: " + ring + " successor: " + successor);
             assertEquals(successor, views.get(successor).getRing(ring).successor(test.getNode(), m -> !m.isFailed()));
             assertTrue(successor.isLive());
-            test.getService().gossip();
+            test.getService().gossip(null);
         } finally {
             views.values().forEach(e -> e.getService().stop());
         }

--- a/fireflies/src/test/java/com/salesforce/apollo/fireflies/SuccessorTest.java
+++ b/fireflies/src/test/java/com/salesforce/apollo/fireflies/SuccessorTest.java
@@ -95,7 +95,7 @@ public class SuccessorTest {
 
         Builder builder = ServerConnectionCache.newBuilder().setTarget(30).setMetrics(metrics);
         Map<Participant, View> views = members.stream().map(node -> {
-            LocalRouter comms = new LocalRouter(node.getId(), builder);
+            LocalRouter comms = new LocalRouter(node, builder, Executors.newFixedThreadPool(3));
             communications.add(comms);
             comms.start();
             return new View(HashKey.ORIGIN, node, comms, metrics);

--- a/fireflies/src/test/java/com/salesforce/apollo/fireflies/SwarmTest.java
+++ b/fireflies/src/test/java/com/salesforce/apollo/fireflies/SwarmTest.java
@@ -225,8 +225,9 @@ public class SwarmTest {
         views = members.stream().map(node -> {
             FireflyMetricsImpl fireflyMetricsImpl = new FireflyMetricsImpl(
                     frist.getAndSet(false) ? node0Registry : registry);
-            Router comms = new LocalRouter(node.getId(),
-                    ServerConnectionCache.newBuilder().setTarget(2).setMetrics(fireflyMetricsImpl));
+            Router comms = new LocalRouter(node,
+                    ServerConnectionCache.newBuilder().setTarget(2).setMetrics(fireflyMetricsImpl),
+                    Executors.newFixedThreadPool(3));
             comms.start();
             communications.add(comms);
             return new View(HashKey.ORIGIN, node, comms, fireflyMetricsImpl);

--- a/ghost/src/test/java/com/salesforce/apollo/ghost/DagTest.java
+++ b/ghost/src/test/java/com/salesforce/apollo/ghost/DagTest.java
@@ -102,7 +102,7 @@ public class DagTest {
         scheduler = Executors.newScheduledThreadPool(100);
 
         views = members.stream().map(node -> {
-            Router comm = new LocalRouter(node.getId(), ServerConnectionCache.newBuilder());
+            Router comm = new LocalRouter(node, ServerConnectionCache.newBuilder(), Executors.newFixedThreadPool(3));
             comms.add(comm);
             View view = new View(HashKey.ORIGIN, node, comm, null);
             return view;

--- a/ghost/src/test/java/com/salesforce/apollo/ghost/GhostTest.java
+++ b/ghost/src/test/java/com/salesforce/apollo/ghost/GhostTest.java
@@ -100,7 +100,7 @@ public class GhostTest {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(10);
 
         views = members.stream().map(node -> {
-            Router com = new LocalRouter(node.getId(), ServerConnectionCache.newBuilder());
+            Router com = new LocalRouter(node, ServerConnectionCache.newBuilder(), Executors.newFixedThreadPool(3));
             comms.add(com);
             View view = new View(HashKey.ORIGIN, node, com, null);
             return view;

--- a/memberships/src/main/java/com/salesforce/apollo/comm/MtlsRouter.java
+++ b/memberships/src/main/java/com/salesforce/apollo/comm/MtlsRouter.java
@@ -7,6 +7,7 @@
 package com.salesforce.apollo.comm;
 
 import java.io.IOException;
+import java.util.concurrent.Executor;
 
 import com.salesforce.apollo.comm.ServerConnectionCache.ServerConnectionFactory;
 import com.salesforce.apollo.comm.grpc.MtlsClient;
@@ -40,15 +41,16 @@ public class MtlsRouter extends Router {
     private final EndpointProvider epProvider;
     private final MtlsServer       server;
 
-    public MtlsRouter(ServerConnectionCache.Builder builder, EndpointProvider ep) {
-        this(builder, ep, new MutableHandlerRegistry());
+    public MtlsRouter(ServerConnectionCache.Builder builder, EndpointProvider ep, Executor executor) {
+        this(builder, ep, new MutableHandlerRegistry(), executor);
     }
 
-    public MtlsRouter(ServerConnectionCache.Builder builder, EndpointProvider ep, MutableHandlerRegistry registry) {
+    public MtlsRouter(ServerConnectionCache.Builder builder, EndpointProvider ep, MutableHandlerRegistry registry,
+            Executor executor) {
         super(builder.setFactory(new MtlsServerConnectionFactory(ep)).build(), registry);
         epProvider = ep;
         this.server = new MtlsServer(epProvider.getBindAddress(), epProvider.getClientAuth(), epProvider.getAlias(),
-                epProvider.getCertificate(), epProvider.getPrivateKey(), epProvider.getValiator(), registry);
+                epProvider.getCertificate(), epProvider.getPrivateKey(), epProvider.getValiator(), registry, executor);
     }
 
     @Override

--- a/memberships/src/test/java/com/salesforce/apollo/membership/messaging/MemberOrderTest.java
+++ b/memberships/src/test/java/com/salesforce/apollo/membership/messaging/MemberOrderTest.java
@@ -140,7 +140,8 @@ public class MemberOrderTest {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(members.size());
 
         messengers = members.stream().map(node -> {
-            LocalRouter comms = new LocalRouter(node.getId(), ServerConnectionCache.newBuilder().setTarget(30));
+            LocalRouter comms = new LocalRouter(node, ServerConnectionCache.newBuilder().setTarget(30),
+                    Executors.newFixedThreadPool(3));
             communications.add(comms);
             comms.start();
             return new Messenger(node, () -> forSigning(node), context, comms, parameters);
@@ -195,7 +196,8 @@ public class MemberOrderTest {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(members.size());
 
         messengers = members.stream().map(node -> {
-            LocalRouter comms = new LocalRouter(node.getId(), ServerConnectionCache.newBuilder().setTarget(30));
+            LocalRouter comms = new LocalRouter(node, ServerConnectionCache.newBuilder().setTarget(30),
+                    Executors.newFixedThreadPool(3));
             communications.add(comms);
             comms.start();
             return new Messenger(node, () -> forSigning(node), context, comms, parameters);

--- a/memberships/src/test/java/com/salesforce/apollo/membership/messaging/MessageTest.java
+++ b/memberships/src/test/java/com/salesforce/apollo/membership/messaging/MessageTest.java
@@ -106,9 +106,7 @@ public class MessageTest {
     public static final String                             DEFAULT_SIGNATURE_ALGORITHM = "SHA256withRSA";
     private static Map<HashKey, CertificateWithPrivateKey> certs;
 
-    private static final Parameters parameters = Parameters.newBuilder()
-                                                           .setBufferSize(100)
-                                                           .build();
+    private static final Parameters parameters = Parameters.newBuilder().setBufferSize(100).build();
 
     @BeforeAll
     public static void beforeClass() {
@@ -153,7 +151,8 @@ public class MessageTest {
         ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(members.size());
 
         messengers = members.stream().map(node -> {
-            LocalRouter comms = new LocalRouter(node.getId(), ServerConnectionCache.newBuilder().setTarget(30));
+            LocalRouter comms = new LocalRouter(node, ServerConnectionCache.newBuilder().setTarget(30),
+                    Executors.newFixedThreadPool(3));
             communications.add(comms);
             comms.start();
             return new Messenger(node, () -> forSigning(node), context, comms, parameters);

--- a/protocols/src/main/java/com/salesforce/apollo/comm/grpc/MtlsServer.java
+++ b/protocols/src/main/java/com/salesforce/apollo/comm/grpc/MtlsServer.java
@@ -24,6 +24,7 @@ import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -330,7 +331,7 @@ public class MtlsServer implements ClientIdentity {
     private final Context.Key<SSLSession> sslSessionContext = Context.key("SSLSession");
 
     public MtlsServer(SocketAddress address, ClientAuth clientAuth, String alias, X509Certificate certificate,
-            PrivateKey privateKey, CertificateValidator validator, MutableHandlerRegistry registry) {
+            PrivateKey privateKey, CertificateValidator validator, MutableHandlerRegistry registry, Executor executor) {
         this.registry = registry;
 
         NettyServerBuilder builder = NettyServerBuilder.forAddress(address)
@@ -340,6 +341,7 @@ public class MtlsServer implements ClientIdentity {
                                                        .withChildOption(ChannelOption.TCP_NODELAY, true)
                                                        .intercept(interceptor)
                                                        .intercept(EnableCompressionInterceptor.SINGLETON);
+        builder.executor(executor);
         server = builder.build();
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override

--- a/protocols/src/main/java/com/salesforce/apollo/protocols/Avalanche.java
+++ b/protocols/src/main/java/com/salesforce/apollo/protocols/Avalanche.java
@@ -11,8 +11,10 @@ import java.util.List;
 
 import org.apache.commons.math3.util.Pair;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.ByteString;
 import com.salesfoce.apollo.proto.QueryResult;
+import com.salesfoce.apollo.proto.SuppliedDagNodes;
 
 /**
  * @author hal.hildebrand
@@ -20,8 +22,8 @@ import com.salesfoce.apollo.proto.QueryResult;
  */
 public interface Avalanche {
 
-    QueryResult query(HashKey context, List<Pair<HashKey, ByteString>> transactions, Collection<HashKey> wanted);
+    ListenableFuture<QueryResult> query(HashKey context, List<Pair<HashKey, ByteString>> transactions, Collection<HashKey> wanted);
 
-    List<ByteString> requestDAG(HashKey context, Collection<HashKey> want);
+    ListenableFuture<SuppliedDagNodes> requestDAG(HashKey context, Collection<HashKey> want);
 
 }

--- a/protocols/src/main/java/com/salesforce/apollo/protocols/Fireflies.java
+++ b/protocols/src/main/java/com/salesforce/apollo/protocols/Fireflies.java
@@ -6,6 +6,7 @@
  */
 package com.salesforce.apollo.protocols;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.salesfoce.apollo.proto.Digests;
 import com.salesfoce.apollo.proto.Gossip;
 import com.salesfoce.apollo.proto.Signed;
@@ -17,7 +18,7 @@ import com.salesfoce.apollo.proto.Update;
  */
 public interface Fireflies {
 
-    Gossip gossip(HashKey id, Signed note, int ring, Digests gossip);
+    ListenableFuture<Gossip> gossip(HashKey id, Signed note, int ring, Digests gossip);
 
     int ping(HashKey id, int ping);
 

--- a/protocols/src/main/java/com/salesforce/apollo/protocols/Messaging.java
+++ b/protocols/src/main/java/com/salesforce/apollo/protocols/Messaging.java
@@ -6,6 +6,7 @@
  */
 package com.salesforce.apollo.protocols;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.salesfoce.apollo.proto.MessageBff;
 import com.salesfoce.apollo.proto.Messages;
 import com.salesfoce.apollo.proto.Push;
@@ -16,7 +17,7 @@ import com.salesfoce.apollo.proto.Push;
  */
 public interface Messaging {
 
-    Messages gossip(MessageBff bff);
+    ListenableFuture<Messages> gossip(MessageBff bff);
 
     void update(Push push);
 

--- a/protocols/src/test/java/com/salesforce/apollo/comm/grpc/TestMtls.java
+++ b/protocols/src/test/java/com/salesforce/apollo/comm/grpc/TestMtls.java
@@ -11,6 +11,7 @@ import static io.github.olivierlemasle.ca.CA.dn;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.net.InetSocketAddress;
+import java.util.concurrent.ForkJoinPool;
 
 import org.junit.jupiter.api.Test;
 
@@ -109,7 +110,7 @@ public class TestMtls {
         CertificateWithPrivateKey serverCert = serverIdentity(ca);
 
         MtlsServer server = new MtlsServer(serverAddress, ClientAuth.REQUIRE, "foo", serverCert.getX509Certificate(),
-                serverCert.getPrivateKey(), validator(), new MutableHandlerRegistry());
+                serverCert.getPrivateKey(), validator(), new MutableHandlerRegistry(), ForkJoinPool.commonPool());
         return server;
     }
 

--- a/sql-state/src/test/java/com/salesforce/apollo/state/AvaTest.java
+++ b/sql-state/src/test/java/com/salesforce/apollo/state/AvaTest.java
@@ -138,7 +138,8 @@ public class AvaTest {
 
         assertEquals(testCardinality, members.size());
 
-        members.forEach(node -> communications.put(node.getId(), new LocalRouter(node.getId(), builder)));
+        members.forEach(node -> communications.put(node.getId(),
+                                                   new LocalRouter(node, builder, Executors.newFixedThreadPool(3))));
 
     }
 
@@ -328,7 +329,8 @@ public class AvaTest {
             aParams.noOpQueryFactor = 40;
 
             AvaAdapter adapter = adapters.get(node);
-            Avalanche ava = new Avalanche(node, view, communications.get(node.getId()), aParams, null, adapter, new MVStore.Builder().open());
+            Avalanche ava = new Avalanche(node, view, communications.get(node.getId()), aParams, null, adapter,
+                    new MVStore.Builder().open());
             adapter.setAva(ava);
             avas.put(node, ava);
         });

--- a/sql-state/src/test/java/com/salesforce/apollo/state/ConsortiumTest.java
+++ b/sql-state/src/test/java/com/salesforce/apollo/state/ConsortiumTest.java
@@ -127,7 +127,8 @@ public class ConsortiumTest {
 
         assertEquals(testCardinality, members.size());
 
-        members.forEach(node -> communications.put(node.getId(), new LocalRouter(node.getId(), builder)));
+        members.forEach(node -> communications.put(node.getId(),
+                                                   new LocalRouter(node, builder, Executors.newFixedThreadPool(3))));
 
         System.out.println(members.stream().map(m -> m.getId()).collect(Collectors.toList()));
 


### PR DESCRIPTION
Use async completion of RPCs.  Apollo is largely composed of broadcast protocols which complete asynchronously - bounded or unbounded.  Convert all the protocols to asynchronous forms.

Throughput is slightly increased.  Thread count is improved.

Moar concurrency work on avalanche DAG working state n' friends.