### PR TITLE
Txn rate limiting revamp

### DIFF
--- a/choam/src/main/java/com/salesforce/apollo/choam/CHOAM.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/CHOAM.java
@@ -41,8 +41,6 @@ import org.slf4j.LoggerFactory;
 
 import com.chiralbehaviors.tron.Fsm;
 import com.google.common.base.Function;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -69,9 +67,13 @@ import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesfoce.apollo.utils.proto.PubKey;
 import com.salesforce.apollo.choam.comm.Concierge;
+import com.salesforce.apollo.choam.comm.Submitter;
 import com.salesforce.apollo.choam.comm.Terminal;
 import com.salesforce.apollo.choam.comm.TerminalClient;
 import com.salesforce.apollo.choam.comm.TerminalServer;
+import com.salesforce.apollo.choam.comm.TxnSubmission;
+import com.salesforce.apollo.choam.comm.TxnSubmitClient;
+import com.salesforce.apollo.choam.comm.TxnSubmitServer;
 import com.salesforce.apollo.choam.fsm.Combine;
 import com.salesforce.apollo.choam.fsm.Merchantile;
 import com.salesforce.apollo.choam.support.Bootstrapper;
@@ -99,7 +101,6 @@ import com.salesforce.apollo.utils.RoundScheduler;
 import com.salesforce.apollo.utils.Utils;
 import com.salesforce.apollo.utils.bloomFilters.BloomFilter;
 
-import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
 /**
@@ -223,6 +224,13 @@ public class CHOAM {
         }
     }
 
+    public class TransSubmission implements Submitter {
+        @Override
+        public SubmitResult submit(SubmitTransaction request, Digest from) {
+            return CHOAM.this.submit(request, from);
+        }
+    }
+
     public class Trampoline implements Concierge {
 
         @Override
@@ -243,11 +251,6 @@ public class CHOAM {
         @Override
         public ViewMember join(JoinRequest request, Digest from) {
             return CHOAM.this.join(request, from);
-        }
-
-        @Override
-        public SubmitResult submit(SubmitTransaction request, Digest from) {
-            return CHOAM.this.submit(request, from);
         }
 
         @Override
@@ -324,34 +327,33 @@ public class CHOAM {
         }
 
         @Override
-        public ListenableFuture<SubmitResult> submitTxn(Transaction transaction) {
+        public SubmitResult submitTxn(Transaction transaction) {
             Member target = servers.next();
-            try (var link = comm.apply(target, params.member())) {
+            try (var link = submissionComm.apply(target, params.member())) {
                 if (link == null) {
                     log.debug("No link for: {} for submitting txn on: {}", target.getId(), params.member());
-                    SettableFuture<SubmitResult> f = SettableFuture.create();
-                    f.set(SubmitResult.newBuilder().setResult(Result.UNAVAILABLE).build());
-                    return f;
+                    return SubmitResult.newBuilder().setResult(Result.UNAVAILABLE).build();
                 }
-//                log.trace("Submitting received txn: {} to: {} in: {} on: {}",
-//                          hashOf(transaction, params.digestAlgorithm()), target.getId(), viewId, params.member());
+                if (log.isTraceEnabled()) {
+                    log.trace("Submitting received txn: {} to: {} in: {} on: {}",
+                              hashOf(transaction, params.digestAlgorithm()), target.getId(), viewId, params.member());
+                }
                 return link.submit(SubmitTransaction.newBuilder()
                                                     .setContext(params.context().getId().toDigeste())
                                                     .setTransaction(transaction)
                                                     .build());
             } catch (StatusRuntimeException e) {
-                SettableFuture<SubmitResult> f = SettableFuture.create();
-                f.set(SubmitResult.newBuilder()
-                                  .setResult(Result.ERROR_SUBMITTING)
-                                  .setErrorMsg(e.getStatus().toString())
-                                  .build());
-                return f;
+                log.trace("Failed submitting txn: {} status:{} to: {} in: {} on: {}",
+                          hashOf(transaction, params.digestAlgorithm()), e.getStatus(), target.getId(), viewId,
+                          params.member());
+                return SubmitResult.newBuilder()
+                                   .setResult(Result.ERROR_SUBMITTING)
+                                   .setErrorMsg(e.getStatus().toString())
+                                   .build();
             } catch (Throwable e) {
                 log.debug("Failed submitting txn: {} to: {} in: {} on: {}",
                           hashOf(transaction, params.digestAlgorithm()), target.getId(), viewId, params.member(), e);
-                SettableFuture<SubmitResult> f = SettableFuture.create();
-                f.set(SubmitResult.newBuilder().setResult(Result.ERROR_SUBMITTING).setErrorMsg(e.toString()).build());
-                return f;
+                return SubmitResult.newBuilder().setResult(Result.ERROR_SUBMITTING).setErrorMsg(e.toString()).build();
             }
         }
 
@@ -618,6 +620,7 @@ public class CHOAM {
     private final AtomicReference<HashedCertifiedBlock>                 checkpoint            = new AtomicReference<>();
     private final ReliableBroadcaster                                   combine;
     private final CommonCommunications<Terminal, Concierge>             comm;
+    private final CommonCommunications<TxnSubmission, Submitter>        submissionComm;
     private final AtomicReference<Committee>                            current               = new AtomicReference<>();
     private final ExecutorService                                       executions;
     private final AtomicReference<CompletableFuture<SynchronizedState>> futureBootstrap       = new AtomicReference<>();
@@ -671,6 +674,13 @@ public class CHOAM {
                                                      params.metrics(), r),
                              TerminalClient.getCreate(params.metrics()),
                              Terminal.getLocalLoopback(params.member(), service));
+        final Submitter txnSubmissionService = new TransSubmission();
+        submissionComm = params.communications()
+                               .create(params.member(), params.context().getId(), txnSubmissionService,
+                                       r -> new TxnSubmitServer(params.communications().getClientIdentityProvider(),
+                                                                params.metrics(), r),
+                                       TxnSubmitClient.getCreate(params.metrics()),
+                                       TxnSubmission.getLocalLoopback(params.member(), txnSubmissionService));
         var fsm = Fsm.construct(new Combiner(), Combine.Transitions.class, Merchantile.INITIAL, true);
         fsm.setName("CHOAM" + params.member().getId() + params.context().getId());
         transitions = fsm.getTransitions();
@@ -1154,23 +1164,20 @@ public class CHOAM {
         restore();
     }
 
-    private Function<SubmittedTransaction, ListenableFuture<SubmitResult>> service() {
+    private Function<SubmittedTransaction, SubmitResult> service() {
         return stx -> {
-//            log.trace("Submitting transaction: {} in service() on: {}", stx.hash(), params.member());
-            SettableFuture<SubmitResult> f = SettableFuture.create();
+//            log.trace("Submitting transaction: {} in service() on: {}", stx.hash(), params.member()); 
             final var c = current.get();
             if (c == null) {
-                f.set(SubmitResult.newBuilder().setResult(Result.NO_COMMITTEE).build());
-                return f;
+                return SubmitResult.newBuilder().setResult(Result.NO_COMMITTEE).build();
             }
             try {
                 return c.submitTxn(stx.transaction());
             } catch (StatusRuntimeException e) {
-                f.set(SubmitResult.newBuilder()
-                                  .setResult(Result.ERROR_SUBMITTING)
-                                  .setErrorMsg(e.getStatus().toString())
-                                  .build());
-                return f;
+                return SubmitResult.newBuilder()
+                                   .setResult(Result.ERROR_SUBMITTING)
+                                   .setErrorMsg(e.getStatus().toString())
+                                   .build();
             }
         };
     }

--- a/choam/src/main/java/com/salesforce/apollo/choam/Committee.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/Committee.java
@@ -21,6 +21,7 @@ import com.salesfoce.apollo.choam.proto.Certification;
 import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Reconfigure;
 import com.salesfoce.apollo.choam.proto.SubmitResult;
+import com.salesfoce.apollo.choam.proto.SubmitResult.Result;
 import com.salesfoce.apollo.choam.proto.SubmitTransaction;
 import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesfoce.apollo.choam.proto.ViewMember;
@@ -33,8 +34,6 @@ import com.salesforce.apollo.crypto.Verifier.DefaultVerifier;
 import com.salesforce.apollo.membership.Context;
 import com.salesforce.apollo.membership.ContextImpl;
 import com.salesforce.apollo.membership.Member;
-
-import io.grpc.Status;
 
 /**
  * @author hal.hildebrand
@@ -102,18 +101,13 @@ public interface Committee {
 
     default SubmitResult submit(SubmitTransaction request) {
         log().debug("Cannot submit txn, inactive committee: {} on: {}", getClass().getSimpleName(), params().member());
-        return SubmitResult.newBuilder()
-                           .setSuccess(false)
-                           .setStatus("Cannot submit txn, inactive committee: " + getClass().getSimpleName() + " on: "
-                           + params().member())
-                           .build();
+        return SubmitResult.newBuilder().setResult(Result.INACTIVE).build();
     }
 
-    default ListenableFuture<Status> submitTxn(Transaction transaction) {
+    default ListenableFuture<SubmitResult> submitTxn(Transaction transaction) {
         log().debug("Cannot process txn, inactive committee: {} on: {}", getClass().getSimpleName(), params().member());
-        SettableFuture<Status> f = SettableFuture.create();
-        f.set(Status.UNAVAILABLE.withDescription("Cannot process txn, inactive committee: " + getClass().getSimpleName()
-        + "on: " + params().member()));
+        SettableFuture<SubmitResult> f = SettableFuture.create();
+        f.set(SubmitResult.newBuilder().setResult(Result.UNAVAILABLE).build());
         return f;
     }
 

--- a/choam/src/main/java/com/salesforce/apollo/choam/Committee.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/Committee.java
@@ -15,8 +15,6 @@ import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import com.salesfoce.apollo.choam.proto.Certification;
 import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Reconfigure;
@@ -104,11 +102,9 @@ public interface Committee {
         return SubmitResult.newBuilder().setResult(Result.INACTIVE).build();
     }
 
-    default ListenableFuture<SubmitResult> submitTxn(Transaction transaction) {
+    default SubmitResult submitTxn(Transaction transaction) {
         log().debug("Cannot process txn, inactive committee: {} on: {}", getClass().getSimpleName(), params().member());
-        SettableFuture<SubmitResult> f = SettableFuture.create();
-        f.set(SubmitResult.newBuilder().setResult(Result.UNAVAILABLE).build());
-        return f;
+        return SubmitResult.newBuilder().setResult(Result.UNAVAILABLE).build();
     }
 
     boolean validate(HashedCertifiedBlock hb);

--- a/choam/src/main/java/com/salesforce/apollo/choam/GenesisAssembly.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/GenesisAssembly.java
@@ -109,6 +109,7 @@ public class GenesisAssembly implements Genesis {
             config.setPid(pid).setnProc((short) view.roster().size());
         }
         config.setEpochLength(7).setNumberOfEpochs(3);
+        config.setLabel("Genesis Assembly" + view.context().getId() + " on: " + params().member().getId());
         controller = new Ethereal().deterministic(config.build(), dataSource(),
                                                   (preblock, last) -> transitions.process(preblock, last),
                                                   epoch -> transitions.nextEpoch(epoch));
@@ -119,7 +120,7 @@ public class GenesisAssembly implements Genesis {
                                                                      : params().metrics().getReconfigureMetrics());
 
         log.debug("Genesis Assembly: {} recontext: {} next assembly: {} on: {}", view.context().getId(),
-                  reContext.getId(), nextAssembly.keySet(), params().member());
+                  reContext.getId(), nextAssembly.keySet(), params().member().getId());
     }
 
     @Override
@@ -133,7 +134,7 @@ public class GenesisAssembly implements Genesis {
                                                        new NullBlock(params().digestAlgorithm())));
         var validate = view.generateValidation(reconfiguration);
         log.trace("Certifying genesis block: {} for: {} count: {} on: {}", reconfiguration.hash, view.context().getId(),
-                  slate.size(), params().member());
+                  slate.size(), params().member().getId());
         ds = new OneShot();
         ds.setValue(validate.toByteString());
     }
@@ -215,7 +216,7 @@ public class GenesisAssembly implements Genesis {
                  .forEach(v -> b.addCertifications(v.getWitness()));
         view.publish(new HashedCertifiedBlock(params().digestAlgorithm(), b.build()));
         log.debug("Genesis block: {} published for: {} on: {}", reconfiguration.hash, view.context().getId(),
-                  params().member());
+                  params().member().getId());
     }
 
     public void start() {
@@ -229,7 +230,7 @@ public class GenesisAssembly implements Genesis {
         if (!started.compareAndSet(true, false)) {
             return;
         }
-        log.trace("Stopping view assembly: {} on: {}", view.context().getId(), params().member());
+        log.trace("Stopping view assembly: {} on: {}", view.context().getId(), params().member().getId());
         coordinator.stop();
         controller.stop();
         final var cur = blockingThread;
@@ -241,10 +242,10 @@ public class GenesisAssembly implements Genesis {
 
     private void certify(Validate v) {
         log.trace("Validating reconfiguration block: {} height: {} on: {}", reconfiguration.hash,
-                  reconfiguration.height(), params().member());
+                  reconfiguration.height(), params().member().getId());
         if (!view.validate(reconfiguration, v)) {
             log.warn("Cannot validate reconfiguration block: {} produced on: {}", reconfiguration.hash,
-                     params().member());
+                     params().member().getId());
             return;
         }
         var member = view.context().getMember(Digest.from(v.getWitness().getId()));
@@ -283,7 +284,7 @@ public class GenesisAssembly implements Genesis {
         if (m == null) {
             if (log.isTraceEnabled()) {
                 log.trace("Invalid view member: {} on: {}", ViewContext.print(vm, params().digestAlgorithm()),
-                          params().member());
+                          params().member().getId());
             }
             return;
         }
@@ -296,7 +297,7 @@ public class GenesisAssembly implements Genesis {
         if (!m.verify(signature(vm.getSignature()), encoded.toByteString())) {
             if (log.isTraceEnabled()) {
                 log.trace("Could not verify consensus key from view member: {} on: {}",
-                          ViewContext.print(vm, params().digestAlgorithm()), params().member());
+                          ViewContext.print(vm, params().digestAlgorithm()), params().member().getId());
             }
             return;
         }
@@ -305,13 +306,13 @@ public class GenesisAssembly implements Genesis {
         if (consensusKey == null) {
             if (log.isTraceEnabled()) {
                 log.trace("Could not deserialize consensus key from view member: {} on: {}",
-                          ViewContext.print(vm, params().digestAlgorithm()), params().member());
+                          ViewContext.print(vm, params().digestAlgorithm()), params().member().getId());
             }
             return;
         }
         if (log.isTraceEnabled()) {
             log.trace("Valid view member: {} on: {}", ViewContext.print(vm, params().digestAlgorithm()),
-                      params().member());
+                      params().member().getId());
         }
         var proposed = proposals.computeIfAbsent(mid, k -> new Proposed(join, m));
         if (join.getEndorsementsList().size() == 1) {
@@ -335,7 +336,7 @@ public class GenesisAssembly implements Genesis {
         final var cid = Digest.from(v.getWitness().getId());
         var certifier = view.context().getMember(cid);
         if (certifier == null) {
-            log.warn("Unknown certifier: {} on: {}", cid, params().member());
+            log.warn("Unknown certifier: {} on: {}", cid, params().member().getId());
             return; // do not have the join yet
         }
         final var hash = Digest.from(v.getHash());
@@ -345,16 +346,16 @@ public class GenesisAssembly implements Genesis {
         }
         var proposed = proposals.get(hash);
         if (proposed == null) {
-            log.warn("Invalid certification, unknown view join: {} on: {}", hash, params().member());
+            log.warn("Invalid certification, unknown view join: {} on: {}", hash, params().member().getId());
             return; // do not have the join yet
         }
         if (!view.validate(proposed.join.getMember(), v)) {
             log.warn("Invalid cetification for view join: {} from: {} on: {}", hash,
-                     Digest.from(v.getWitness().getId()), params().member());
+                     Digest.from(v.getWitness().getId()), params().member().getId());
             return;
         }
         proposed.certifications.put(certifier, v.getWitness());
         log.debug("Validation of view member: {}:{} using certifier: {} on: {}", member.getId(), hash,
-                  certifier.getId(), params().member());
+                  certifier.getId(), params().member().getId());
     }
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/Parameters.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/Parameters.java
@@ -513,12 +513,12 @@ public record Parameters(RuntimeParameters runtime, ReliableBroadcaster.Paramete
 
     public static class LimiterBuilder {
         private Duration backlogDuration = Duration.ofSeconds(1);
-        private int      backlogSize     = 100;
+        private int      backlogSize     = 1_000;
         private double   backoffRatio    = 0.9;
         private int      initialLimit    = 1_000;
         private int      maxLimit        = 5_000;
-        private int      minLimit        = 100;
-        private Duration timeout         = Duration.ofSeconds(2);
+        private int      minLimit        = 1_000;
+        private Duration timeout         = Duration.ofSeconds(1);
 
         public Limiter<Void> build(String name, MetricRegistry metrics) {
             final SimpleLimiter<Void> limiter = SimpleLimiter.newBuilder()

--- a/choam/src/main/java/com/salesforce/apollo/choam/Producer.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/Producer.java
@@ -60,6 +60,7 @@ public class Producer {
 
         @Override
         public void assembled() {
+            assembly.stop();
             final var slate = assembly.getSlate();
             var reconfiguration = new HashedBlock(params().digestAlgorithm(),
                                                   view.reconfigure(slate, nextViewId, previousBlock.get()));

--- a/choam/src/main/java/com/salesforce/apollo/choam/Producer.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/Producer.java
@@ -24,6 +24,7 @@ import com.salesfoce.apollo.choam.proto.Block;
 import com.salesfoce.apollo.choam.proto.CertifiedBlock;
 import com.salesfoce.apollo.choam.proto.Executions;
 import com.salesfoce.apollo.choam.proto.SubmitResult;
+import com.salesfoce.apollo.choam.proto.SubmitResult.Result;
 import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesfoce.apollo.choam.proto.UnitData;
 import com.salesfoce.apollo.choam.proto.Validate;
@@ -204,8 +205,7 @@ public class Producer {
                                                   epoch -> newEpoch(epoch));
         var producerMetrics = params().metrics() == null ? null : params().metrics().getProducerMetrics();
         coordinator = new ContextGossiper(controller, view.context(), params().member(), params().communications(),
-                                          params().exec(),
-                                          producerMetrics);
+                                          params().exec(), producerMetrics);
         log.debug("Roster for: {} is: {} on: {}", getViewId(), view.roster(), params().member());
     }
 
@@ -250,14 +250,11 @@ public class Producer {
         if (ds.offer(transaction)) {
             log.trace("Successful submit of txn: {} on: {}", CHOAM.hashOf(transaction, params().digestAlgorithm()),
                       params().member());
-            return SubmitResult.newBuilder().setSuccess(true).setStatus("OK").build();
+            return SubmitResult.newBuilder().setResult(Result.PUBLISHED).build();
         } else {
             log.trace("Unsuccessful submit of txn: {} on: {}", CHOAM.hashOf(transaction, params().digestAlgorithm()),
                       params().member());
-            return SubmitResult.newBuilder()
-                               .setSuccess(false)
-                               .setStatus("Transaction buffer full on: " + params().member().getId())
-                               .build();
+            return SubmitResult.newBuilder().setResult(Result.BUFFER_FULL).build();
         }
     }
 

--- a/choam/src/main/java/com/salesforce/apollo/choam/ViewAssembly.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/ViewAssembly.java
@@ -160,6 +160,7 @@ public class ViewAssembly implements Reconfiguration {
     @Override
     public void complete() {
         log.debug("View Assembly: {} completed with: {} members on: {}", nextViewId, slate.size(), params().member());
+        transitions.complete();
     }
 
     @Override
@@ -180,6 +181,7 @@ public class ViewAssembly implements Reconfiguration {
 
     @Override
     public void failed() {
+        log.error("Failed view assembly for: {} on: {}", nextViewId, params().member());
         stop();
     }
 

--- a/choam/src/main/java/com/salesforce/apollo/choam/ViewAssembly.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/ViewAssembly.java
@@ -130,10 +130,15 @@ public class ViewAssembly implements Reconfiguration {
             pid++;
         }
         config.setPid(pid).setnProc((short) view.roster().size());
-        config.setEpochLength(7).setNumberOfEpochs(epochs());
+        config.setEpochLength(3).setNumberOfEpochs(3);
+        config.setLabel("View Recon" + nextViewId + " on: " + params().member().getId());
         controller = new Ethereal().deterministic(config.build(), dataSource(),
-                                                  (preblock, last) -> process(preblock, last),
-                                                  epoch -> transitions.nextEpoch(epoch));
+                                                  (preblock, last) -> process(preblock, last), epoch -> {
+                                                      log.trace("Next epoch: {} state: {} on: {}", epoch,
+                                                                transitions.fsm().getCurrentState(),
+                                                                params().member().getId());
+                                                      transitions.nextEpoch(epoch);
+                                                  });
 
         coordinator = new ContextGossiper(controller, reContext, params().member(), params().communications(),
                                           params().exec(),
@@ -141,13 +146,14 @@ public class ViewAssembly implements Reconfiguration {
                                                                      : params().metrics().getReconfigureMetrics());
 
         log.debug("View Assembly from: {} to: {} recontext: {} next assembly: {} on: {}", view.context().getId(),
-                  nextViewId, reContext.getId(), nextAssembly.keySet(), params().member());
+                  nextViewId, reContext.getId(), nextAssembly.keySet(), params().member().getId());
     }
 
     @Override
     public void certify() {
         ds = new OneShot();
-        log.debug("Certifying Join proposals of: {} count: {} on: {}", nextViewId, proposals.size(), params().member());
+        log.debug("Certifying Join proposals of: {} count: {} state: {} on: {}", nextViewId, proposals.size(),
+                  transitions.fsm().getCurrentState(), params().member());
         ds.setValue(Reassemble.newBuilder()
                               .setValidations(Validations.newBuilder()
                                                          .addAllValidations(proposals.values().stream().map(p -> {
@@ -159,7 +165,8 @@ public class ViewAssembly implements Reconfiguration {
 
     @Override
     public void complete() {
-        log.debug("View Assembly: {} completed with: {} members on: {}", nextViewId, slate.size(), params().member());
+        log.debug("View Assembly: {} completed with: {} members state: {} on: {}", nextViewId, slate.size(),
+                  transitions.fsm().getCurrentState(), params().member().getId());
         transitions.complete();
     }
 
@@ -171,23 +178,27 @@ public class ViewAssembly implements Reconfiguration {
                  .sorted(Comparator.comparing(p -> p.member.getId()))
                  .forEach(p -> slate.put(p.member(), joinOf(p)));
         if (slate.size() > params().toleranceLevel()) {
-            log.debug("Electing slate: {} of: {} on: {}", slate.size(), nextViewId, params().member());
+            log.debug("Electing slate: {} of: {} state: {} on: {}", slate.size(), nextViewId,
+                      transitions.fsm().getCurrentState(), params().member());
             transitions.complete();
         } else {
-            log.debug("Failed to elect slate: {} of: {} on: {}", slate.size(), nextViewId, params().member());
+            log.debug("Failed to elect slate: {} of: {} state: {} on: {}", slate.size(), nextViewId,
+                      transitions.fsm().getCurrentState(), params().member().getId());
             transitions.failed();
         }
     }
 
     @Override
     public void failed() {
-        log.error("Failed view assembly for: {} on: {}", nextViewId, params().member());
+        log.error("Failed view assembly for: {} state: {} on: {}", nextViewId, transitions.fsm().getCurrentState(),
+                  params().member());
         stop();
     }
 
     @Override
     public void gather() {
-        log.trace("Gathering assembly for: {} on: {}", nextViewId, params().member());
+        log.trace("Gathering assembly for: {} state: {} on: {}", nextViewId, transitions.fsm().getCurrentState(),
+                  params().member());
         JoinRequest request = JoinRequest.newBuilder()
                                          .setContext(params().context().getId().toDigeste())
                                          .setNextView(nextViewId.toDigeste())
@@ -200,7 +211,8 @@ public class ViewAssembly implements Reconfiguration {
             if (proposals.containsKey(m.getId())) {
                 return null;
             }
-            log.trace("Requesting Join from: {} on: {}", term.getMember().getId(), params().member());
+            log.trace("Requesting Join from: {} state: {} on: {}", term.getMember().getId(),
+                      transitions.fsm().getCurrentState(), params().member().getId());
             return term.join(request);
         }, (futureSailor, term, m) -> consider(futureSailor, term, m, proceed),
                                               () -> completeSlice(retryDelay, proceed, reiterate, countDown)));
@@ -214,8 +226,9 @@ public class ViewAssembly implements Reconfiguration {
 
     @Override
     public void nominate() {
-        log.debug("Nominating proposal for: {} members: {} on: {}", nextViewId,
-                  proposals.values().stream().map(p -> p.member.getId()).toList(), params().member());
+        log.debug("Nominating proposal for: {} members: {} state: {} on: {}", nextViewId,
+                  proposals.values().stream().map(p -> p.member.getId()).toList(), transitions.fsm().getCurrentState(),
+                  params().member().getId());
         ds.setValue(Reassemble.newBuilder()
                               .setViewMembers(ViewMembers.newBuilder()
                                                          .addAllMembers(proposals.values()
@@ -244,7 +257,8 @@ public class ViewAssembly implements Reconfiguration {
         if (!started.compareAndSet(true, false)) {
             return;
         }
-        log.trace("Stopping view assembly: {} on: {}", nextViewId, params().member());
+        log.trace("Stopping view assembly: {} state: {} on: {}", nextViewId, transitions.fsm().getCurrentState(),
+                  params().member());
         coordinator.stop();
         controller.stop();
         final var cur = blockingThread;
@@ -252,10 +266,6 @@ public class ViewAssembly implements Reconfiguration {
         if (cur != null) {
             cur.interrupt();
         }
-    }
-
-    protected int epochs() {
-        return 3;
     }
 
     protected Reconfigure getStartState() {
@@ -266,27 +276,32 @@ public class ViewAssembly implements Reconfiguration {
         final var cid = Digest.from(v.getWitness().getId());
         var certifier = view.context().getMember(cid);
         if (certifier == null) {
-            log.warn("Unknown certifier: {} on: {}", cid, params().member());
+            log.warn("Unknown certifier: {} state: {} on: {}", cid, transitions.fsm().getCurrentState(),
+                     params().member());
             return; // do not have the join yet
         }
         final var hash = Digest.from(v.getHash());
         final var member = nextAssembly.get(hash);
         if (member == null) {
+            log.warn("Unknown validation member: {} state: {} on: {}", hash, transitions.fsm().getCurrentState(),
+                     params().member());
             return;
         }
         var proposed = proposals.get(hash);
         if (proposed == null) {
-            log.warn("Invalid certification, unknown view join: {} on: {}", hash, params().member());
+            log.warn("Invalid certification, unknown view join: {} state: {} on: {}", hash,
+                     transitions.fsm().getCurrentState(), params().member().getId());
             return; // do not have the join yet
         }
         if (!view.validate(proposed.vm, v)) {
-            log.warn("Invalid cetification for view join: {} from: {} on: {}", hash,
-                     Digest.from(v.getWitness().getId()), params().member());
+            log.warn("Invalid cetification for view join: {} state: {} from: {} on: {}", hash,
+                     Digest.from(v.getWitness().getId()), transitions.fsm().getCurrentState(),
+                     params().member().getId());
             return;
         }
         proposed.validations.put(certifier, v);
-        log.debug("Validation of view member: {}:{} using certifier: {} on: {}", member.getId(), hash,
-                  certifier.getId(), params().member());
+        log.debug("Validation of view member: {}:{} using certifier: {} state: {} on: {}", member.getId(), hash,
+                  certifier.getId(), transitions.fsm().getCurrentState(), params().member().getId());
     }
 
     void assembled() {
@@ -298,7 +313,8 @@ public class ViewAssembly implements Reconfiguration {
         final var count = proposals.size();
         if (count == nextAssembly.size()) {
             proceed.set(false);
-            log.trace("Proposal assembled: {} on: {}", nextViewId, params().member());
+            log.trace("Proposal assembled: {} state: {} on: {}", nextViewId, transitions.fsm().getCurrentState(),
+                      params().member().getId());
             transitions.gathered();
             return;
         }
@@ -310,21 +326,23 @@ public class ViewAssembly implements Reconfiguration {
 
         if (count > params().toleranceLevel()) {
             if (countDown.decrementAndGet() >= 0) {
-                log.trace("Retrying, attempting full assembly of: {} gathered: {} desired: {} on: {}", nextViewId,
-                          proposals.keySet().stream().toList(), nextAssembly.size(), params().member());
+                log.trace("Retrying, attempting full assembly of: {} gathered: {} desired: {} delay: {} state: {} on: {}",
+                          nextViewId, proposals.keySet().stream().toList(), nextAssembly.size(), delay,
+                          transitions.fsm().getCurrentState(), params().member().getId());
                 proceed.set(true);
                 params().scheduler().schedule(() -> reiterate.get().run(), delay.toMillis(), TimeUnit.MILLISECONDS);
                 return;
             }
             proceed.set(false);
-            log.trace("Proposal assembled: {} gathered: {} out of: {} on: {}", nextViewId, count, nextAssembly.size(),
-                      params().member());
+            log.trace("Proposal assembled: {} gathered: {} out of: {} state: {} on: {}", nextViewId, count,
+                      nextAssembly.size(), transitions.fsm().getCurrentState(), params().member().getId());
             transitions.gathered();
             return;
         }
 
-        log.trace("Proposal incomplete of: {} gathered: {} required: {}, retrying on: {}", nextViewId,
-                  proposals.keySet().stream().toList(), params().toleranceLevel() + 1, params().member());
+        log.trace("Proposal incomplete of: {} gathered: {} required: {}, retrying: {} state: {} on: {}", nextViewId,
+                  proposals.keySet().stream().toList(), params().toleranceLevel() + 1, delay,
+                  transitions.fsm().getCurrentState(), params().member().getId());
         proceed.set(true);
         params().scheduler().schedule(() -> reiterate.get().run(), delay.toMillis(), TimeUnit.MILLISECONDS);
     }
@@ -337,31 +355,38 @@ public class ViewAssembly implements Reconfiguration {
         ViewMember member;
         try {
             member = futureSailor.get().get();
-            log.debug("Join reply from: {} on: {}", term.getMember().getId(), params().member().getId());
+            log.debug("Join reply from: {} state: {} on: {}", term.getMember().getId(),
+                      transitions.fsm().getCurrentState(), params().member().getId());
         } catch (InterruptedException e) {
-            log.debug("Error join response from: {} on: {}", term.getMember().getId(), params().member().getId(), e);
+            log.debug("Error join response from: {} state: {} on: {}", term.getMember().getId(),
+                      transitions.fsm().getCurrentState(), params().member().getId(), e);
             return proceed.get();
         } catch (ExecutionException e) {
             var cause = e.getCause();
             if (cause instanceof StatusRuntimeException sre) {
                 if (!sre.getStatus().getCode().equals(Status.UNAVAILABLE.getCode())) {
-                    log.debug("Error join response from: {} on: {}", term.getMember().getId(),
-                              params().member().getId(), sre);
+                    log.debug("Error join response from: {} state: {} on: {}", term.getMember().getId(),
+                              transitions.fsm().getCurrentState(), params().member().getId(), sre);
                 }
+            } else {
+                log.trace("Error join response from: {} state: {} on: {}", term.getMember().getId(),
+                          transitions.fsm().getCurrentState(), params().member().getId(), e.getCause());
             }
             return proceed.get();
         }
         if (member.equals(ViewMember.getDefaultInstance())) {
-            log.debug("Empty join response from: {} on: {}", term.getMember().getId(), params().member().getId());
+            log.debug("Empty join response from: {} state: {} on: {}", term.getMember().getId(),
+                      transitions.fsm().getCurrentState(), params().member().getId());
             return proceed.get();
         }
         var vm = new Digest(member.getId());
         if (!m.getId().equals(vm)) {
-            log.debug("Invalid join response from: {} expected: {} on: {}", term.getMember().getId(), vm,
-                      params().member().getId());
+            log.debug("Invalid join response from: {} expected: {} state: {} on: {}", term.getMember().getId(), vm,
+                      transitions.fsm().getCurrentState(), params().member().getId());
             return proceed.get();
         }
-        log.debug("Adding delegate to: {} from: {} on: {}", getViewId(), term.getMember().getId(), params().member());
+        log.debug("Adding delegate to: {} from: {} state: {} on: {}", getViewId(), term.getMember().getId(),
+                  transitions.fsm().getCurrentState(), params().member().getId());
         join(member);
 
         return proceed.get();
@@ -376,7 +401,11 @@ public class ViewAssembly implements Reconfiguration {
                 }
                 try {
                     blockingThread = Thread.currentThread();
+                    log.trace("Waiting for data state: {} on: {}", transitions.fsm().getCurrentState(),
+                              params().member().getId());
                     final var take = ds.get();
+                    log.trace("Data received: {}, state: {} proceeding on: {}", take.size(),
+                              transitions.fsm().getCurrentState(), params().member().getId());
                     return take;
                 } finally {
                     blockingThread = null;
@@ -394,8 +423,8 @@ public class ViewAssembly implements Reconfiguration {
         final var m = nextAssembly.get(mid);
         if (m == null) {
             if (log.isTraceEnabled()) {
-                log.trace("Invalid view member: {} on: {}", ViewContext.print(vm, params().digestAlgorithm()),
-                          params().member());
+                log.trace("Invalid view member: {} state: {} on: {}", ViewContext.print(vm, params().digestAlgorithm()),
+                          transitions.fsm().getCurrentState(), params().member().getId());
             }
             return;
         }
@@ -404,8 +433,9 @@ public class ViewAssembly implements Reconfiguration {
 
         if (!m.verify(signature(vm.getSignature()), encoded.toByteString())) {
             if (log.isTraceEnabled()) {
-                log.trace("Could not verify consensus key from view member: {} on: {}",
-                          ViewContext.print(vm, params().digestAlgorithm()), params().member());
+                log.trace("Could not verify consensus key from view member: {} state: {} on: {}",
+                          ViewContext.print(vm, params().digestAlgorithm()), transitions.fsm().getCurrentState(),
+                          params().member().getId());
             }
             return;
         }
@@ -413,14 +443,15 @@ public class ViewAssembly implements Reconfiguration {
         PublicKey consensusKey = publicKey(encoded);
         if (consensusKey == null) {
             if (log.isTraceEnabled()) {
-                log.trace("Could not deserialize consensus key from view member: {} on: {}",
-                          ViewContext.print(vm, params().digestAlgorithm()), params().member());
+                log.trace("Could not deserialize consensus key from view member: {} state: {} on: {}",
+                          ViewContext.print(vm, params().digestAlgorithm()), transitions.fsm().getCurrentState(),
+                          params().member().getId());
             }
             return;
         }
         if (log.isTraceEnabled()) {
-            log.trace("Valid view member: {} on: {}", ViewContext.print(vm, params().digestAlgorithm()),
-                      params().member());
+            log.trace("Valid view member: {} state: {} on: {}", ViewContext.print(vm, params().digestAlgorithm()),
+                      transitions.fsm().getCurrentState(), params().member().getId());
         }
         proposals.computeIfAbsent(mid, k -> new Proposed(vm, m, new ConcurrentHashMap<>()));
     }
@@ -439,11 +470,15 @@ public class ViewAssembly implements Reconfiguration {
     }
 
     private void process(PreBlock preblock, boolean last) {
+        log.trace("Preblock last: {} state: {} on: {}", last, transitions.fsm().getCurrentState(),
+                  params().member().getId());
         preblock.data().stream().map(e -> {
             try {
-                return Reassemble.parseFrom(e);
+                final var parseFrom = Reassemble.parseFrom(e);
+                return parseFrom;
             } catch (InvalidProtocolBufferException ex) {
-                log.trace("Error parsing Reassemble on: {}", params().member());
+                log.trace("Error parsing Reassemble state: {} on: {}", transitions.fsm().getCurrentState(),
+                          params().member().getId());
                 return (Reassemble) null;
             }
         }).filter(e -> e != null).forEach(re -> process(re));
@@ -454,7 +489,8 @@ public class ViewAssembly implements Reconfiguration {
 
     private void process(Reassemble re) {
         if (re.getAssemblyCase() != AssemblyCase.ASSEMBLY_NOT_SET) {
-            log.trace("Processing: {} on: {}", re.getAssemblyCase(), params().member());
+            log.trace("Processing: {} state: {} on: {}", re.getAssemblyCase(), transitions.fsm().getCurrentState(),
+                      params().member().getId());
         }
         switch (re.getAssemblyCase()) {
         case VALIDATIONS:

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/Concierge.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/Concierge.java
@@ -12,8 +12,6 @@ import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
 import com.salesfoce.apollo.choam.proto.JoinRequest;
-import com.salesfoce.apollo.choam.proto.SubmitResult;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesforce.apollo.crypto.Digest;
@@ -31,8 +29,6 @@ public interface Concierge {
     Blocks fetchViewChain(BlockReplication request, Digest from);
 
     ViewMember join(JoinRequest request, Digest from);
-
-    SubmitResult submit(SubmitTransaction request, Digest from);
 
     Initial sync(Synchronize request, Digest from);
 

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/Submitter.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/Submitter.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.apollo.choam.comm;
+
+import com.salesfoce.apollo.choam.proto.SubmitResult;
+import com.salesfoce.apollo.choam.proto.SubmitTransaction;
+import com.salesforce.apollo.crypto.Digest;
+
+/**
+ * @author hal.hildebrand
+ *
+ */
+public interface Submitter {
+
+    SubmitResult submit(SubmitTransaction request, Digest from);
+
+}

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/Terminal.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/Terminal.java
@@ -14,14 +14,13 @@ import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
 import com.salesfoce.apollo.choam.proto.JoinRequest;
+import com.salesfoce.apollo.choam.proto.SubmitResult;
 import com.salesfoce.apollo.choam.proto.SubmitTransaction;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesforce.apollo.comm.Link;
 import com.salesforce.apollo.membership.Member;
 import com.salesforce.apollo.membership.SigningMember;
-
-import io.grpc.Status;
 
 /**
  * Terminal RPC endpoint for CHOAM
@@ -66,14 +65,9 @@ public interface Terminal extends Link {
             }
 
             @Override
-            public ListenableFuture<Status> submit(SubmitTransaction request) {
-                SettableFuture<Status> f = SettableFuture.create();
-                var result = service.submit(request, member.getId()); 
-                if (result.getSuccess()) {
-                    f.set(Status.OK);
-                } else {
-                    f.set(Status.UNAVAILABLE.withDescription(result.getStatus()));
-                }
+            public ListenableFuture<SubmitResult> submit(SubmitTransaction request) {
+                SettableFuture<SubmitResult> f = SettableFuture.create();
+                f.set(service.submit(request, member.getId()));
                 return f;
             }
 
@@ -84,6 +78,7 @@ public interface Terminal extends Link {
         };
     }
 
+    @Override
     void close();
 
     ListenableFuture<CheckpointSegments> fetch(CheckpointReplication request);
@@ -94,7 +89,7 @@ public interface Terminal extends Link {
 
     ListenableFuture<ViewMember> join(JoinRequest join);
 
-    ListenableFuture<Status> submit(SubmitTransaction request);
+    ListenableFuture<SubmitResult> submit(SubmitTransaction request);
 
     ListenableFuture<Initial> sync(Synchronize sync);
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/Terminal.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/Terminal.java
@@ -14,8 +14,6 @@ import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
 import com.salesfoce.apollo.choam.proto.JoinRequest;
-import com.salesfoce.apollo.choam.proto.SubmitResult;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesforce.apollo.comm.Link;
@@ -65,21 +63,11 @@ public interface Terminal extends Link {
             }
 
             @Override
-            public ListenableFuture<SubmitResult> submit(SubmitTransaction request) {
-                SettableFuture<SubmitResult> f = SettableFuture.create();
-                f.set(service.submit(request, member.getId()));
-                return f;
-            }
-
-            @Override
             public ListenableFuture<Initial> sync(Synchronize sync) {
                 return null;
             }
         };
     }
-
-    @Override
-    void close();
 
     ListenableFuture<CheckpointSegments> fetch(CheckpointReplication request);
 
@@ -88,8 +76,6 @@ public interface Terminal extends Link {
     ListenableFuture<Blocks> fetchViewChain(BlockReplication replication);
 
     ListenableFuture<ViewMember> join(JoinRequest join);
-
-    ListenableFuture<SubmitResult> submit(SubmitTransaction request);
 
     ListenableFuture<Initial> sync(Synchronize sync);
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TerminalClient.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TerminalClient.java
@@ -13,8 +13,6 @@ import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
 import com.salesfoce.apollo.choam.proto.JoinRequest;
-import com.salesfoce.apollo.choam.proto.SubmitResult;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.TerminalGrpc;
 import com.salesfoce.apollo.choam.proto.TerminalGrpc.TerminalFutureStub;
@@ -81,11 +79,6 @@ public class TerminalClient implements Terminal {
 
     public void release() {
         close();
-    }
-
-    @Override
-    public ListenableFuture<SubmitResult> submit(SubmitTransaction request) {
-        return client.submit(request);
     }
 
     @Override

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TerminalServer.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TerminalServer.java
@@ -12,8 +12,6 @@ import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
 import com.salesfoce.apollo.choam.proto.JoinRequest;
-import com.salesfoce.apollo.choam.proto.SubmitResult;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.TerminalGrpc.TerminalImplBase;
 import com.salesfoce.apollo.choam.proto.ViewMember;
@@ -22,7 +20,6 @@ import com.salesforce.apollo.comm.RoutableService;
 import com.salesforce.apollo.crypto.Digest;
 import com.salesforce.apollo.protocols.ClientIdentity;
 
-import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 
 /**
@@ -80,23 +77,6 @@ public class TerminalServer extends TerminalImplBase {
             }
             responseObserver.onNext(s.join(request, from));
             responseObserver.onCompleted();
-        });
-    }
-
-    @Override
-    public void submit(SubmitTransaction request, StreamObserver<SubmitResult> responseObserver) {
-        router.evaluate(responseObserver, request.hasContext() ? new Digest(request.getContext()) : null, s -> {
-            Digest from = identity.getFrom();
-            if (from == null) {
-                responseObserver.onError(new IllegalStateException("Member has been removed"));
-                return;
-            }
-            try {
-                responseObserver.onNext(s.submit(request, from));
-                responseObserver.onCompleted();
-            } catch (StatusRuntimeException e) {
-                responseObserver.onError(e);
-            }
         });
     }
 

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmission.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmission.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.apollo.choam.comm;
+
+import java.io.IOException;
+
+import com.salesfoce.apollo.choam.proto.SubmitResult;
+import com.salesfoce.apollo.choam.proto.SubmitTransaction;
+import com.salesforce.apollo.comm.Link;
+import com.salesforce.apollo.membership.Member;
+import com.salesforce.apollo.membership.SigningMember;
+
+/**
+ * @author hal.hildebrand
+ *
+ */
+public interface TxnSubmission extends Link {
+    static TxnSubmission getLocalLoopback(SigningMember member, Submitter service) {
+        return new TxnSubmission() {
+
+            @Override
+            public void close() throws IOException {
+
+            }
+
+            @Override
+            public Member getMember() {
+                return member;
+            }
+
+            @Override
+            public SubmitResult submit(SubmitTransaction request) {
+                return service.submit(request, member.getId());
+            }
+        };
+    }
+
+    SubmitResult submit(SubmitTransaction request);
+}

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitClient.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitClient.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.apollo.choam.comm;
+
+import com.salesfoce.apollo.choam.proto.SubmitResult;
+import com.salesfoce.apollo.choam.proto.SubmitTransaction;
+import com.salesfoce.apollo.choam.proto.TransactionSubmissionGrpc;
+import com.salesfoce.apollo.choam.proto.TransactionSubmissionGrpc.TransactionSubmissionBlockingStub;
+import com.salesforce.apollo.choam.support.ChoamMetrics;
+import com.salesforce.apollo.comm.ServerConnectionCache.CreateClientCommunications;
+import com.salesforce.apollo.comm.ServerConnectionCache.ManagedServerConnection;
+import com.salesforce.apollo.membership.Member;
+
+/**
+ * @author hal.hildebrand
+ *
+ */
+public class TxnSubmitClient implements TxnSubmission {
+
+    public static CreateClientCommunications<TxnSubmission> getCreate(ChoamMetrics metrics) {
+        return (t, f, c) -> new TxnSubmitClient(c, t, metrics);
+
+    }
+
+    private final ManagedServerConnection channel;
+
+    private final TransactionSubmissionBlockingStub client;
+    private final Member                            member;
+    @SuppressWarnings("unused")
+    private final ChoamMetrics                      metrics;
+
+    public TxnSubmitClient(ManagedServerConnection channel, Member member, ChoamMetrics metrics) {
+        this.member = member;
+        this.channel = channel;
+        this.client = TransactionSubmissionGrpc.newBlockingStub(channel.channel).withCompression("gzip");
+        this.metrics = metrics;
+    }
+
+    @Override
+    public void close() {
+        channel.release();
+    }
+
+    @Override
+    public Member getMember() {
+        return member;
+    }
+
+    public void release() {
+        close();
+    }
+
+    @Override
+    public SubmitResult submit(SubmitTransaction request) {
+        return client.submit(request);
+    }
+}

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitServer.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitServer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+package com.salesforce.apollo.choam.comm;
+
+import com.salesfoce.apollo.choam.proto.SubmitResult;
+import com.salesfoce.apollo.choam.proto.SubmitTransaction;
+import com.salesfoce.apollo.choam.proto.TransactionSubmissionGrpc.TransactionSubmissionImplBase;
+import com.salesforce.apollo.choam.support.ChoamMetrics;
+import com.salesforce.apollo.comm.RoutableService;
+import com.salesforce.apollo.crypto.Digest;
+import com.salesforce.apollo.protocols.ClientIdentity;
+
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+/**
+ * @author hal.hildebrand
+ *
+ */
+public class TxnSubmitServer extends TransactionSubmissionImplBase {
+    private ClientIdentity                   identity;
+    @SuppressWarnings("unused")
+    private final ChoamMetrics               metrics;
+    private final RoutableService<Submitter> router;
+
+    public TxnSubmitServer(ClientIdentity identity, ChoamMetrics metrics, RoutableService<Submitter> router) {
+        this.metrics = metrics;
+        this.identity = identity;
+        this.router = router;
+    }
+
+    @Override
+    public void submit(SubmitTransaction request, StreamObserver<SubmitResult> responseObserver) {
+        router.evaluate(responseObserver, request.hasContext() ? new Digest(request.getContext()) : null, s -> {
+            Digest from = identity.getFrom();
+            if (from == null) {
+                responseObserver.onError(new IllegalStateException("Member has been removed"));
+                return;
+            }
+            try {
+                responseObserver.onNext(s.submit(request, from));
+                responseObserver.onCompleted();
+            } catch (StatusRuntimeException e) {
+                responseObserver.onError(e);
+            }
+        });
+    }
+}

--- a/choam/src/main/java/com/salesforce/apollo/choam/fsm/Reconfiguration.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/fsm/Reconfiguration.java
@@ -36,17 +36,9 @@ public interface Reconfiguration {
         default Transitions nextEpoch(int epoch) {
             throw fsm().invalidTransitionOn();
         }
-
-        default Transitions reconfigureBlock() {
-            throw fsm().invalidTransitionOn();
-        }
     }
 
     void certify();
-
-    default void certifyBlock() {
-        // do nothing
-    }
 
     void complete();
 
@@ -57,8 +49,4 @@ public interface Reconfiguration {
     void gather();
 
     void nominate();
-
-    default void produceBlock() {
-        // do nothing
-    }
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/fsm/Reconfigure.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/fsm/Reconfigure.java
@@ -15,6 +15,7 @@ import com.salesforce.apollo.choam.fsm.Reconfiguration.Transitions;
  */
 public enum Reconfigure implements Transitions {
     AWAIT_ASSEMBLY {
+        @Override
         public Transitions assembled() {
             return GATHER;
         }
@@ -82,24 +83,6 @@ public enum Reconfigure implements Transitions {
             context().elect();
         }
     },
-    RECONFIGURE_BLOCK {
-        @Entry
-        public void certifyBlock() {
-            context().certifyBlock();
-        }
-
-        @Override
-        public Transitions complete() {
-            context().produceBlock();
-            return null;
-        }
-
-        @Override
-        public Transitions nextEpoch(int epoch) {
-            return null;
-        }
-
-    },
     RECONFIGURED {
 
         @Override
@@ -115,11 +98,6 @@ public enum Reconfigure implements Transitions {
         @Override
         public Transitions nextEpoch(int epoch) {
             return null;
-        }
-
-        @Override
-        public Transitions reconfigureBlock() {
-            return RECONFIGURE_BLOCK;
         }
     };
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/support/ChoamMetrics.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/support/ChoamMetrics.java
@@ -34,6 +34,8 @@ public interface ChoamMetrics extends EdpointMetrics {
 
     Timer transactionLatency();
 
+    void transactionSubmitRetry();
+
     void transactionSubmittedBufferFull();
 
     void transactionSubmittedFail();

--- a/choam/src/main/java/com/salesforce/apollo/choam/support/ChoamMetricsImpl.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/support/ChoamMetricsImpl.java
@@ -42,6 +42,7 @@ public class ChoamMetricsImpl extends EndpointMetricsImpl implements ChoamMetric
     private final MetricRegistry  registry;
     private final Timer           transactionLatency;
     private final Meter           transactionSubmitFailed;
+    private final Meter           transactionSubmitRetry;
     private final Meter           transactionSubmitSuccess;
     private final Meter           transactionSubmittedBufferFull;
     private final Meter           transactionTimeout;
@@ -59,6 +60,7 @@ public class ChoamMetricsImpl extends EndpointMetricsImpl implements ChoamMetric
         publishedBytes = registry.histogram(name(context.shortString(), "unit.bytes"));
         publishedValidations = registry.meter(name(context.shortString(), "validations.published"));
         transactionLatency = registry.timer(name(context.shortString(), "transaction.latency"));
+        transactionSubmitRetry = registry.meter(name(context.shortString(), "transaction.submit.retry"));
         transactionSubmitFailed = registry.meter(name(context.shortString(), "transaction.submit.failed"));
         transactionSubmitSuccess = registry.meter(name(context.shortString(), "transaction.submit.success"));
         transactionTimeout = registry.meter(name(context.shortString(), "transaction.timeout"));
@@ -119,6 +121,11 @@ public class ChoamMetricsImpl extends EndpointMetricsImpl implements ChoamMetric
     @Override
     public Timer transactionLatency() {
         return transactionLatency;
+    }
+
+    @Override
+    public void transactionSubmitRetry() {
+        transactionSubmitRetry.mark();
     }
 
     @Override

--- a/choam/src/main/java/com/salesforce/apollo/choam/support/TxDataSource.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/support/TxDataSource.java
@@ -12,7 +12,6 @@ import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;

--- a/choam/src/main/java/com/salesforce/apollo/choam/support/TxDataSource.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/support/TxDataSource.java
@@ -108,11 +108,12 @@ public class TxDataSource implements DataSource {
             mode.set(Mode.CLOSED);
             blockingThread = Thread.currentThread();
             try {
-                Validate validation = validations.poll(1, TimeUnit.SECONDS);
-                while (validation == null) {
-                    validation = validations.poll(2, TimeUnit.MILLISECONDS);
+                Validate validation = validations.take();
+                if (validation != null) {
+                    builder.addValidations(validation);
+                } else {
+                    System.out.println("No waiting validations on: " + member.getId());
                 }
-                builder.addValidations(validation);
             } catch (InterruptedException e) {
                 return ByteString.EMPTY;
             } finally {

--- a/choam/src/main/proto/choam.proto
+++ b/choam/src/main/proto/choam.proto
@@ -4,9 +4,6 @@ option java_multiple_files = true;
 option java_package = "com.salesfoce.apollo.choam.proto";
 option java_outer_classname = "ChoamProto";
 option objc_class_prefix = "Chp";
-import "google/protobuf/any.proto";
-import "google/protobuf/empty.proto";
-import "google/protobuf/timestamp.proto";
 import "util.proto";
 import "stereotomy.proto";
 
@@ -36,8 +33,18 @@ message SubmitTransaction {
 }
 
 message SubmitResult {
-    bool success = 1;
-    string status = 2;
+    enum Result {
+        INVALID_RESULT = 0;
+        PUBLISHED = 1;
+        BUFFER_FULL = 2;
+        INACTIVE = 3;
+        NO_COMMITTEE = 4;
+        UNAVAILABLE = 6;
+        INVALID_SUBMIT = 7;
+        ERROR_SUBMITTING = 8;
+    }
+    Result result = 1;
+    string errorMsg = 2;
 }
 
 message Block {

--- a/choam/src/main/proto/choam.proto
+++ b/choam/src/main/proto/choam.proto
@@ -9,9 +9,11 @@ import "stereotomy.proto";
 
 package apollo.choam;
 
-service Terminal {
+service TransactionSubmission {
     rpc submit (SubmitTransaction) returns (SubmitResult) {}
+}
 
+service Terminal {
     /* reconfiguration */
     rpc join (JoinRequest) returns (ViewMember) {}
 

--- a/choam/src/test/java/com/salesforce/apollo/choam/MembershipTests.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/MembershipTests.java
@@ -92,8 +92,8 @@ public class MembershipTests {
         assertTrue(Utils.waitForCondition(120_00, 1000, () -> txneer.active()), "Transactioneer did not become active");
 
         final var countdown = new CountDownLatch(1);
-        var transactioneer = new Transactioneer(txneer.getSession(), timeout, 1, scheduler, countdown,
-                                                Executors.newSingleThreadExecutor());
+        var transactioneer = new Transactioneer(txneer.getSession(), Executors.newSingleThreadExecutor(), timeout, 1,
+                                                scheduler, countdown, Executors.newSingleThreadExecutor());
 
         transactioneer.start();
         assertTrue(countdown.await(timeout.toSeconds(), TimeUnit.SECONDS), "Could not submit transaction");

--- a/choam/src/test/java/com/salesforce/apollo/choam/SessionTest.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/SessionTest.java
@@ -26,8 +26,6 @@ import com.codahale.metrics.ConsoleReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Function;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
@@ -67,7 +65,7 @@ public class SessionTest {
                                                               .setMember(new SigningMemberImpl(Utils.getMember(0)))
                                                               .build());
         @SuppressWarnings("unchecked")
-        Function<SubmittedTransaction, ListenableFuture<SubmitResult>> service = stx -> {
+        Function<SubmittedTransaction, SubmitResult> service = stx -> {
             ForkJoinPool.commonPool().execute(() -> {
                 try {
                     Thread.sleep(100);
@@ -80,9 +78,7 @@ public class SessionTest {
                     throw new IllegalStateException(e);
                 }
             });
-            SettableFuture<SubmitResult> f = SettableFuture.create();
-            f.set(SubmitResult.newBuilder().setResult(Result.PUBLISHED).build());
-            return f;
+            return SubmitResult.newBuilder().setResult(Result.PUBLISHED).build();
         };
         Session session = new Session(params, service);
         final String content = "Give me food or give me slack or kill me";
@@ -105,7 +101,7 @@ public class SessionTest {
                                                               .build());
 
         @SuppressWarnings("unchecked")
-        Function<SubmittedTransaction, ListenableFuture<SubmitResult>> service = stx -> {
+        Function<SubmittedTransaction, SubmitResult> service = stx -> {
             exec.execute(() -> {
                 try {
                     Thread.sleep(1);
@@ -118,9 +114,7 @@ public class SessionTest {
                     throw new IllegalStateException(e);
                 }
             });
-            SettableFuture<SubmitResult> f = SettableFuture.create();
-            f.set(SubmitResult.newBuilder().setResult(Result.PUBLISHED).build());
-            return f;
+            return SubmitResult.newBuilder().setResult(Result.PUBLISHED).build();
         };
 
         MetricRegistry reg = new MetricRegistry();

--- a/choam/src/test/java/com/salesforce/apollo/choam/SessionTest.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/SessionTest.java
@@ -31,6 +31,8 @@ import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
+import com.salesfoce.apollo.choam.proto.SubmitResult;
+import com.salesfoce.apollo.choam.proto.SubmitResult.Result;
 import com.salesfoce.apollo.ethereal.proto.ByteMessage;
 import com.salesforce.apollo.choam.Parameters.RuntimeParameters;
 import com.salesforce.apollo.choam.support.InvalidTransaction;
@@ -42,7 +44,6 @@ import com.salesforce.apollo.membership.Member;
 import com.salesforce.apollo.membership.impl.SigningMemberImpl;
 import com.salesforce.apollo.utils.Utils;
 
-import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 
 /**
@@ -66,7 +67,7 @@ public class SessionTest {
                                                               .setMember(new SigningMemberImpl(Utils.getMember(0)))
                                                               .build());
         @SuppressWarnings("unchecked")
-        Function<SubmittedTransaction, ListenableFuture<Status>> service = stx -> {
+        Function<SubmittedTransaction, ListenableFuture<SubmitResult>> service = stx -> {
             ForkJoinPool.commonPool().execute(() -> {
                 try {
                     Thread.sleep(100);
@@ -79,8 +80,8 @@ public class SessionTest {
                     throw new IllegalStateException(e);
                 }
             });
-            SettableFuture<Status> f = SettableFuture.create();
-            f.set(Status.OK);
+            SettableFuture<SubmitResult> f = SettableFuture.create();
+            f.set(SubmitResult.newBuilder().setResult(Result.PUBLISHED).build());
             return f;
         };
         Session session = new Session(params, service);
@@ -104,7 +105,7 @@ public class SessionTest {
                                                               .build());
 
         @SuppressWarnings("unchecked")
-        Function<SubmittedTransaction, ListenableFuture<Status>> service = stx -> {
+        Function<SubmittedTransaction, ListenableFuture<SubmitResult>> service = stx -> {
             exec.execute(() -> {
                 try {
                     Thread.sleep(1);
@@ -117,8 +118,8 @@ public class SessionTest {
                     throw new IllegalStateException(e);
                 }
             });
-            SettableFuture<Status> f = SettableFuture.create();
-            f.set(Status.OK);
+            SettableFuture<SubmitResult> f = SettableFuture.create();
+            f.set(SubmitResult.newBuilder().setResult(Result.PUBLISHED).build());
             return f;
         };
 

--- a/choam/src/test/java/com/salesforce/apollo/choam/TestCHOAM.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/TestCHOAM.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -63,16 +62,13 @@ public class TestCHOAM {
             LoggerFactory.getLogger(TestCHOAM.class).error("Error on thread: {}", t.getName(), e);
         });
     }
-    protected CompletableFuture<Boolean>   checkpointOccurred;
-    private Map<Digest, AtomicInteger>     blocks;
-    private Map<Digest, CHOAM>             choams;
-    private ExecutorService                exec;
-    private List<SigningMember>            members;
-    private MetricRegistry                 registry;
-    private Map<Digest, Router>            routers;
-    private Map<Digest, List<Transaction>> transactions;
-    private ExecutorService                txExecutor;
-    private ScheduledExecutorService       txScheduler;;
+    protected CompletableFuture<Boolean> checkpointOccurred;
+    private Map<Digest, AtomicInteger>   blocks;
+    private Map<Digest, CHOAM>           choams;
+    private ExecutorService              exec;
+    private List<SigningMember>          members;
+    private MetricRegistry               registry;
+    private Map<Digest, Router>          routers;
 
     @AfterEach
     public void after() throws Exception {
@@ -89,26 +85,15 @@ public class TestCHOAM {
         if (exec != null) {
             exec.shutdown();
         }
-        if (txScheduler != null) {
-            txScheduler.shutdown();
-        }
-        if (txExecutor != null) {
-            txExecutor.shutdown();
-        }
         exec = null;
-        txScheduler = null;
-        txExecutor = null;
     }
 
     @BeforeEach
     public void before() {
         exec = Executors.newFixedThreadPool(CARDINALITY);
-        txScheduler = Executors.newScheduledThreadPool(CARDINALITY);
-        txExecutor = Executors.newFixedThreadPool(CARDINALITY);
         var context = new ContextImpl<>(DigestAlgorithm.DEFAULT.getOrigin(), CARDINALITY, 0.2, 3);
         registry = new MetricRegistry();
         var metrics = new ChoamMetricsImpl(context.getId(), registry);
-        transactions = new ConcurrentHashMap<>();
         blocks = new ConcurrentHashMap<>();
         Random entropy = new Random();
         var scheduler = Executors.newScheduledThreadPool(CARDINALITY);
@@ -119,8 +104,8 @@ public class TestCHOAM {
                                .setGenesisViewId(DigestAlgorithm.DEFAULT.getOrigin().prefix(entropy.nextLong()))
                                .setGossipDuration(Duration.ofMillis(10))
                                .setProducer(ProducerParameters.newBuilder()
-                                                              .setMaxBatchCount(10_000)
-                                                              .setMaxBatchByteSize(10 * 1024 * 1024)
+                                                              .setMaxBatchCount(15_000)
+                                                              .setMaxBatchByteSize(200 * 1024 * 1024)
                                                               .setGossipDuration(Duration.ofMillis(10))
                                                               .setBatchInterval(Duration.ofMillis(50))
                                                               .build())
@@ -149,15 +134,9 @@ public class TestCHOAM {
             blocks.put(m.getId(), recording);
             final TransactionExecutor processor = new TransactionExecutor() {
 
-                @Override
-                public void endBlock(ULong height, Digest hash) {
-                    recording.incrementAndGet();
-                }
-
                 @SuppressWarnings({ "unchecked", "rawtypes" })
                 @Override
                 public void execute(int index, Digest hash, Transaction t, CompletableFuture f) {
-                    transactions.computeIfAbsent(m.getId(), d -> new ArrayList<>()).add(t);
                     if (f != null) {
                         f.complete(new Object());
                     }
@@ -182,24 +161,31 @@ public class TestCHOAM {
         routers.values().forEach(r -> r.start());
         choams.values().forEach(ch -> ch.start());
 
-        final var timeout = Duration.ofSeconds(2);
+        final var timeout = Duration.ofSeconds(3);
 
         final var transactioneers = new ArrayList<Transactioneer>();
         final var clientCount = LARGE_TESTS ? 5_000 : 50;
-        final var max = LARGE_TESTS ? 100 : 10;
+        final var max = LARGE_TESTS ? 500 : 10;
         final var countdown = new CountDownLatch(clientCount * choams.size());
-        for (int i = 0; i < clientCount; i++) {
-            choams.values().stream().map(c -> {
-                return new Transactioneer(c.getSession(), timeout, max, txScheduler, countdown, txExecutor);
-            }).forEach(e -> transactioneers.add(e));
-        }
+
+        choams.values().forEach(c -> {
+            final var txnCompletion = Executors.newFixedThreadPool(2);
+            final var txnExecutor = Executors.newFixedThreadPool(1);
+            final var txScheduler = Executors.newScheduledThreadPool(1);
+            for (int i = 0; i < clientCount; i++) {
+                transactioneers.add(new Transactioneer(c.getSession(), txnCompletion, timeout, max, txScheduler,
+                                                       countdown, txnExecutor));
+            }
+        });
 
         assertTrue(Utils.waitForCondition(30_000, () -> choams.values().stream().filter(c -> !c.active()).count() == 0),
                    "System did not become active");
 
         transactioneers.stream().forEach(e -> e.start());
         try {
-            countdown.await(60, TimeUnit.SECONDS);
+            final var complete = countdown.await(600, TimeUnit.SECONDS);
+            assertTrue(complete, "All clients did not complete: "
+            + transactioneers.stream().map(t -> t.getCompleted()).filter(i -> i < max).count());
         } finally {
             routers.values().forEach(e -> e.close());
             choams.values().forEach(e -> e.stop());

--- a/choam/src/test/java/com/salesforce/apollo/choam/TestCHOAM.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/TestCHOAM.java
@@ -189,15 +189,15 @@ public class TestCHOAM {
         } finally {
             routers.values().forEach(e -> e.close());
             choams.values().forEach(e -> e.stop());
-            System.out.println();
-
-            ConsoleReporter.forRegistry(registry)
-                           .convertRatesTo(TimeUnit.SECONDS)
-                           .convertDurationsTo(TimeUnit.MILLISECONDS)
-                           .build()
-                           .report();
         }
         assertTrue(checkpointOccurred.get());
+        System.out.println();
+
+        ConsoleReporter.forRegistry(registry)
+                       .convertRatesTo(TimeUnit.SECONDS)
+                       .convertDurationsTo(TimeUnit.MILLISECONDS)
+                       .build()
+                       .report();
     }
 
     private Function<ULong, File> wrap(Function<ULong, File> checkpointer) {

--- a/choam/src/test/resources/logback-test.xml
+++ b/choam/src/test/resources/logback-test.xml
@@ -27,6 +27,10 @@
         additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
+    <logger name="com.salesforce.apollo.choam.ViewAssembly" level="info"
+        additivity="false">
+        <appender-ref ref="STDOUT" />
+    </logger>
     
     <logger name="com.chiralbehaviors.tron" level="info"
         additivity="false">

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -6,7 +6,7 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
     <artifactId>demo</artifactId>
-    <name>Demo: RBAC + Identity + Key Management</name>
+    <name>Demo: ReBAC + Identity + Key Management</name>
 
     <dependencies>
         <dependency>

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/Config.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/Config.java
@@ -22,10 +22,11 @@ import com.salesforce.apollo.ethereal.WeakThresholdKey.NoOpWeakThresholdKey;
  * @author hal.hildebrand
  *
  */
-public record Config(short nProc, int epochLength, short pid, int zeroVoteRoundForCommonVote, int firstDecidedRound,
-                     int orderStartLevel, int commonVoteDeterministicPrefix, short crpFixedPrefix, Signer signer,
-                     DigestAlgorithm digestAlgorithm, int lastLevel, boolean canSkipLevel, int numberOfEpochs,
-                     WeakThresholdKey WTKey, Clock clock, double bias, Verifier[] verifiers, double fpr) {
+public record Config(String label, short nProc, int epochLength, short pid, int zeroVoteRoundForCommonVote,
+                     int firstDecidedRound, int orderStartLevel, int commonVoteDeterministicPrefix,
+                     short crpFixedPrefix, Signer signer, DigestAlgorithm digestAlgorithm, int lastLevel,
+                     boolean canSkipLevel, int numberOfEpochs, WeakThresholdKey WTKey, Clock clock, double bias,
+                     Verifier[] verifiers, double fpr) {
 
     public static Builder deterministic() {
         Builder b = new Builder();
@@ -46,20 +47,25 @@ public record Config(short nProc, int epochLength, short pid, int zeroVoteRoundF
         return new Builder(config);
     }
 
+    public String logLabel() {
+        return label + "(" + pid + ")";
+    }
+
     public static class Builder implements Cloneable {
         public static Builder empty() {
             return new Builder().requiredByLinear();
         }
 
         private int              bias                          = 3;
-        private boolean          canSkipLevel                  = false;
+        private boolean          canSkipLevel                  = true;
         private Clock            clock                         = Clock.systemUTC();
-        private short            crpFixedPrefix;
         private short            commonVoteDeterministicPrefix = 10;
+        private short            crpFixedPrefix;
         private DigestAlgorithm  digestAlgorithm               = DigestAlgorithm.DEFAULT;
         private int              epochLength                   = 30;
         private int              firstDecidedRound;
         private double           fpr                           = 0.125;
+        private String           label                         = "";
         private int              lastLevel                     = -1;
         private short            nProc;
         private int              numberOfEpochs                = 3;
@@ -114,7 +120,7 @@ public record Config(short nProc, int epochLength, short pid, int zeroVoteRoundF
 
         public Config build() {
             if (pByz <= -1) {
-                pByz = 1.0 / (double) bias;
+                pByz = 1.0 / bias;
             }
             final var minimalQuorum = Dag.minimalQuorum(nProc, bias);
             if (wtk == null) {
@@ -125,9 +131,9 @@ public record Config(short nProc, int epochLength, short pid, int zeroVoteRoundF
             if (lastLevel <= 0) {
                 addLastLevel();
             }
-            return new Config(nProc, epochLength, pid, zeroVoteRoundForCommonVote, firstDecidedRound, orderStartLevel,
-                              commonVoteDeterministicPrefix, crpFixedPrefix, signer, digestAlgorithm, lastLevel,
-                              canSkipLevel, numberOfEpochs, wtk, clock, bias, verifiers, fpr);
+            return new Config(label, nProc, epochLength, pid, zeroVoteRoundForCommonVote, firstDecidedRound,
+                              orderStartLevel, commonVoteDeterministicPrefix, crpFixedPrefix, signer, digestAlgorithm,
+                              lastLevel, canSkipLevel, numberOfEpochs, wtk, clock, bias, verifiers, fpr);
         }
 
         @Override
@@ -165,6 +171,10 @@ public record Config(short nProc, int epochLength, short pid, int zeroVoteRoundF
 
         public double getFpr() {
             return fpr;
+        }
+
+        public String getLabel() {
+            return label;
         }
 
         public int getLastLevel() {
@@ -254,6 +264,11 @@ public record Config(short nProc, int epochLength, short pid, int zeroVoteRoundF
 
         public Builder setFpr(double fpr) {
             this.fpr = fpr;
+            return this;
+        }
+
+        public Builder setLabel(String label) {
+            this.label = label;
             return this;
         }
 

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/Dag.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/Dag.java
@@ -157,7 +157,7 @@ public interface Dag {
         public void insert(Unit v) {
             if (v.epoch() != epoch) {
                 throw new IllegalStateException("Invalid insert of: " + v + " into epoch: " + epoch + " on: "
-                + config.pid());
+                + config.logLabel());
             }
             write(() -> {
                 var unit = v.embed(this);
@@ -283,7 +283,10 @@ public interface Dag {
         }
 
         private void _sync(Consumer<PreUnit> send) {
-            units.values().stream().filter(u -> u.creator() == config.pid()).map(u -> u.toPreUnit())
+            units.values()
+                 .stream()
+                 .filter(u -> u.creator() == config.pid())
+                 .map(u -> u.toPreUnit())
                  .forEach(pu -> send.accept(pu));
         }
 
@@ -293,7 +296,7 @@ public interface Dag {
             try {
                 return call.call();
             } catch (Exception e) {
-                throw new IllegalStateException("Error during read locked call", e);
+                throw new IllegalStateException("Error during read locked call on: " + config.logLabel(), e);
             } finally {
                 lock.unlock();
             }
@@ -305,7 +308,7 @@ public interface Dag {
             try {
                 r.run();
             } catch (Exception e) {
-                throw new IllegalStateException("Error during read locked call", e);
+                throw new IllegalStateException("Error during read locked call on: " + config.logLabel(), e);
             } finally {
                 lock.unlock();
             }
@@ -353,7 +356,7 @@ public interface Dag {
             try {
                 r.run();
             } catch (Exception e) {
-                throw new IllegalStateException("Error during write locked call", e);
+                throw new IllegalStateException("Error during write locked call on: " + config.logLabel(), e);
             } finally {
                 lock.unlock();
             }
@@ -430,7 +433,8 @@ public interface Dag {
                 throw new IllegalStateException("Wrong number of heights passed to fiber map: " + heights.length
                 + " expected: " + width);
             }
-            List<List<Unit>> result = IntStream.range(0, width).mapToObj(e -> new ArrayList<Unit>())
+            List<List<Unit>> result = IntStream.range(0, width)
+                                               .mapToObj(e -> new ArrayList<Unit>())
                                                .collect(Collectors.toList());
             var unknown = 0;
             final Lock lock = mx.readLock();
@@ -524,7 +528,7 @@ public interface Dag {
     }
 
     static Dag newDag(Config config, int epoch) {
-        log.trace("New dag for epoch: {} on: {}", epoch, config.pid());
+        log.trace("New dag for epoch: {} on: {}", epoch, config.logLabel());
 //        return new dag(config.nProc(), epoch, new ConcurrentHashMap<>(),
 //                       newFiberMap(config.nProc(), config.epochLength()),
 //                       newFiberMap(config.nProc(), config.epochLength()), newSlottedUnits(config.nProc()),

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/Dag.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/Dag.java
@@ -251,11 +251,6 @@ public interface Dag {
             return config.pid();
         }
 
-        @Override
-        public void sync(Consumer<PreUnit> send) {
-            read(() -> _sync(send));
-        }
-
         /**
          * return all units present in dag that are above (in height sense) given
          * heights. When called with null argument, returns all units in the dag. Units
@@ -280,14 +275,6 @@ public interface Dag {
                 var res = levelUnits.getFiber(level);
                 return res != null ? res : newSlottedUnits(config.nProc());
             });
-        }
-
-        private void _sync(Consumer<PreUnit> send) {
-            units.values()
-                 .stream()
-                 .filter(u -> u.creator() == config.pid())
-                 .map(u -> u.toPreUnit())
-                 .forEach(pu -> send.accept(pu));
         }
 
         private <T> T read(Callable<T> call) {
@@ -588,8 +575,6 @@ public interface Dag {
     short nProc();
 
     short pid();
-
-    void sync(Consumer<PreUnit> send);
 
     List<Unit> unitsAbove(int[] heights);
 

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/GossipService.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/GossipService.java
@@ -52,7 +52,7 @@ public class GossipService {
     }
 
     public Gossip gossip(Digest context, int ring) {
-        log.trace("Gossiping for: {} on: {}", context, orderer.getConfig().pid());
+        log.trace("Gossiping for: {} on: {}", context, orderer.getConfig().logLabel());
         mx.lock();
         try {
             return Gossip.newBuilder()
@@ -68,7 +68,7 @@ public class GossipService {
     public Update gossip(Gossip gossip) {
         Update.Builder update = orderer.missing(BloomFilter.from(gossip.getHave()));
         log.trace("GossipService received for: {} missing: {} on: {}", Digest.from(gossip.getContext()),
-                  update.getMissingCount(), orderer.getConfig().pid());
+                  update.getMissingCount(), orderer.getConfig().logLabel());
         return update.setHave(biffs.get(Utils.bitStreamEntropy().nextInt(biffs.size())).toBff()).build();
     }
 
@@ -81,7 +81,7 @@ public class GossipService {
         if (missing.isEmpty()) {
             return;
         }
-        log.trace("GossipService update: {} on: {}", missing.size(), orderer.getConfig().pid());
+        log.trace("GossipService update: {} on: {}", missing.size(), orderer.getConfig().logLabel());
         mx.lock();
         try {
             missing.forEach(pu -> {

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/Orderer.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/Orderer.java
@@ -365,7 +365,6 @@ public class Orderer {
                         if (u.creator() != config.pid()) {
                             creator.consume(Collections.singletonList(u), lastTiming);
                         }
-                        ;
                     } finally {
                         currentThread = null;
                     }

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/linear/Extender.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/linear/Extender.java
@@ -38,13 +38,12 @@ public class Extender {
 
     private final int                               commonVoteDeterministicPrefix;
     private final CommonRandomPermutation           crpIterator;
-    private AtomicReference<Unit>                   currentTU        = new AtomicReference<>();
+    private AtomicReference<Unit>                   currentTU = new AtomicReference<>();
     private final Dag                               dag;
-    private final Map<Digest, SuperMajorityDecider> deciders         = new ConcurrentHashMap<>();
+    private final Map<Digest, SuperMajorityDecider> deciders  = new ConcurrentHashMap<>();
     private final DigestAlgorithm                   digestAlgorithm;
     private final int                               firstDecidedRound;
-    private AtomicBoolean                           lastDecideResult = new AtomicBoolean();
-    private AtomicReference<List<Unit>>             lastTUs          = new AtomicReference<>();
+    private AtomicReference<List<Unit>>             lastTUs   = new AtomicReference<>();
     private final int                               orderStartLevel;
     private final RandomSource                      randomSource;
     private final int                               zeroVoteRoundForCommonVote;
@@ -64,7 +63,6 @@ public class Extender {
     }
 
     public TimingRound nextRound() {
-        lastDecideResult.set(false);
         var dagMaxLevel = dag.maxLevel();
         if (dagMaxLevel < orderStartLevel) {
             log.trace("No round, max dag level: {} is < order start level: {} on: {}", dagMaxLevel, orderStartLevel,
@@ -92,7 +90,6 @@ public class Extender {
                 next.add(previousTU);
                 lastTUs.set(next);
                 currentTU.set(uc);
-                lastDecideResult.set(true);
                 deciders.clear();
                 decided.set(true);
                 log.trace("Round decided");

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/linear/ExtenderService.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/linear/ExtenderService.java
@@ -43,7 +43,7 @@ public class ExtenderService {
     }
 
     public void chooseNextTimingUnits() {
-        log.trace("Signaling to see if we can produce a block on: {}", config.pid());
+        log.trace("Signaling to see if we can produce a block on: {}", config.logLabel());
         timingUnitDecider();
     }
 
@@ -56,11 +56,11 @@ public class ExtenderService {
         exclusive.acquireUninterruptibly();
         try {
             var round = ordering.nextRound();
-            log.trace("Starting timing round: {} on: {}", round, config.pid());
+            log.trace("Starting timing round: {} on: {}", round, config.logLabel());
             while (round != null) {
-                log.debug("Producing timing round: {} on: {}", round, config.pid());
+                log.trace("Producing timing round: {} on: {}", round, config.logLabel());
                 var units = round.orderedUnits(config.digestAlgorithm());
-                log.debug("Output of: {} preBlock: {} on: {}", round, units, config.pid());
+                log.trace("Output of: {} preBlock: {} on: {}", round, units, config.logLabel());
                 output.accept(units);
                 round = ordering.nextRound();
             }

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,12 @@
     </modules>
 
     <properties>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.2</jackson.version>
         <dropwizard.version>2.0.28</dropwizard.version>
         <h2.version>2.1.210</h2.version>
-        <jooq.version>3.16.4</jooq.version>
+        <jooq.version>3.16.5</jooq.version>
         <bc.version>1.70</bc.version>
-        <logback.version>1.2.7</logback.version>
+        <logback.version>1.2.11</logback.version>
         <grpc.version>1.43.1</grpc.version>
         <protobuf.version>3.19.2</protobuf.version>
         <liquibase.version>4.8.0</liquibase.version>
@@ -199,22 +199,6 @@
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bctls-jdk15on</artifactId>
                 <version>${bc.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bctls-fips</artifactId>
-                <version>1.0.12.2</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bc-fips</artifactId>
-                <version>1.0.2.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.bouncycastle</groupId>
-                <artifactId>bcpkix-fips</artifactId>
-                <version>1.0.5</version>
             </dependency>
 
             <dependency>

--- a/protocols/src/main/java/com/netflix/concurrency/limits/limiter/LifoBlockingLimiter.java
+++ b/protocols/src/main/java/com/netflix/concurrency/limits/limiter/LifoBlockingLimiter.java
@@ -196,8 +196,7 @@ public final class LifoBlockingLimiter<ContextT> implements Limiter<ContextT> {
         }
 
         // Create a holder for a listener and block until a listener is released by
-        // another
-        // operation. Holders will be unblocked in LIFO order
+        // another operation. Holders will be unblocked in LIFO order
         backlogCounter.incrementAndGet();
         final ListenerHolder<ContextT> event = new ListenerHolder<>(context);
 
@@ -208,8 +207,8 @@ public final class LifoBlockingLimiter<ContextT> implements Limiter<ContextT> {
 
             if (!event.await(backlogTimeoutMillis.apply(context), TimeUnit.MILLISECONDS)) {
                 // Remove the holder from the backlog. This item is likely to be at the end of
-                // the
-                // list so do a removeLastOccurance to minimize the number of items to traverse
+                // the list so do a removeLastOccurance to minimize the number of items to
+                // traverse
                 synchronized (lock) {
                     backlog.removeLastOccurrence(event);
                 }

--- a/sql-state/src/main/java/com/salesforce/apollo/state/Emulator.java
+++ b/sql-state/src/main/java/com/salesforce/apollo/state/Emulator.java
@@ -19,7 +19,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.joou.ULong;
 
-import com.google.common.util.concurrent.SettableFuture;
 import com.salesfoce.apollo.choam.proto.SubmitResult;
 import com.salesfoce.apollo.choam.proto.SubmitResult.Result;
 import com.salesfoce.apollo.choam.proto.Transaction;
@@ -77,11 +76,9 @@ public class Emulator {
         Session session = new Session(params, st -> {
             lock.lock();
             try {
-                SettableFuture<SubmitResult> f = SettableFuture.create();
                 Transaction txn = st.transaction();
                 txnExec.execute(txnIndex.incrementAndGet(), CHOAM.hashOf(txn, algorithm), txn, st.onCompletion());
-                f.set(SubmitResult.newBuilder().setResult(Result.PUBLISHED).build());
-                return f;
+                return SubmitResult.newBuilder().setResult(Result.PUBLISHED).build();
             } finally {
                 lock.unlock();
             }

--- a/sql-state/src/main/java/com/salesforce/apollo/state/Emulator.java
+++ b/sql-state/src/main/java/com/salesforce/apollo/state/Emulator.java
@@ -20,6 +20,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.joou.ULong;
 
 import com.google.common.util.concurrent.SettableFuture;
+import com.salesfoce.apollo.choam.proto.SubmitResult;
+import com.salesfoce.apollo.choam.proto.SubmitResult.Result;
 import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesfoce.apollo.state.proto.Txn;
 import com.salesforce.apollo.choam.CHOAM;
@@ -32,8 +34,6 @@ import com.salesforce.apollo.crypto.DigestAlgorithm;
 import com.salesforce.apollo.membership.ContextImpl;
 import com.salesforce.apollo.membership.impl.SigningMemberImpl;
 import com.salesforce.apollo.utils.Utils;
-
-import io.grpc.Status;
 
 /**
  * Single node emulation of the SQL State Machine for testing, development, etc.
@@ -77,10 +77,10 @@ public class Emulator {
         Session session = new Session(params, st -> {
             lock.lock();
             try {
-                SettableFuture<Status> f = SettableFuture.create();
+                SettableFuture<SubmitResult> f = SettableFuture.create();
                 Transaction txn = st.transaction();
                 txnExec.execute(txnIndex.incrementAndGet(), CHOAM.hashOf(txn, algorithm), txn, st.onCompletion());
-                f.set(Status.OK);
+                f.set(SubmitResult.newBuilder().setResult(Result.PUBLISHED).build());
                 return f;
             } finally {
                 lock.unlock();

--- a/utils/src/main/java/com/salesforce/apollo/crypto/ProviderUtils.java
+++ b/utils/src/main/java/com/salesforce/apollo/crypto/ProviderUtils.java
@@ -29,7 +29,7 @@ public class ProviderUtils {
         PROVIDER_JSSE = Security.getProvider(PROVIDER_NAME_BCJSSE);
     }
 
-    public static Provider getProviderBC() { 
+    public static Provider getProviderBC() {
         if (!initialized.get()) {
             throw new IllegalStateException("Provider has not been initialized");
         }
@@ -55,10 +55,6 @@ public class ProviderUtils {
         // TODO Use new constructor when available
 //        return new BouncyCastleJsseProvider(fips);
         return new BouncyCastleJsseProvider(fips, new JcaTlsCryptoProvider());
-    }
-
-    static Provider createProviderBCJSSE(boolean fips, Provider bc) {
-        return new BouncyCastleJsseProvider(fips, bc);
     }
 
     static Provider createProviderBCJSSE(Provider bc) {
@@ -114,8 +110,6 @@ public class ProviderUtils {
     }
 
     static void setup(boolean bcPriority, boolean bcjssePriority, boolean fips) {
-        String javaVersion = System.getProperty("java.version");
-        boolean oldJDK = javaVersion.startsWith("1.5") || javaVersion.startsWith("1.6");
 
         Provider bc = getProviderBC();
         Provider bcjsse = getProviderBCJSSE();
@@ -130,7 +124,7 @@ public class ProviderUtils {
             removeProviderBCJSSE();
         }
         if (!isProviderBCJSSE(bcjsse, fips)) {
-            bcjsse = oldJDK ? createProviderBCJSSE(fips, bc) : createProviderBCJSSE(fips);
+            bcjsse = createProviderBCJSSE(fips);
         }
 
         if (bcPriority) {


### PR DESCRIPTION
Reimplement transaction submission rate limiting from clients.  Previously, the scheme was an exp back off per txn - silly, in retrospect.  Now, the system reuses the Netflix AIMD rate limiter with a LIFO blocking limiter wrapper.

Will eventually generalize this, although I'm not sure having "moar choices" will actually be better in this area. So for now this is what I'm going with.

The rate limiting is also sensitive to the failure mode, in that if the txn is blocked because a view change is occurring and the buffers are full, then a simple retry will occur.  Likely this is an area where we can use exp back off, but really, it's not something that needs a rocket science solution. Serious pounding in sims shows that the simple retry is highly effective and doesn't drop any txns during view change while still being smooth.

Changed large scale testing to vastly reduce threads, as piling on threads is like adding lanes to traffic that's already at capacity.  A single thread or 2 on txn submission is more than sufficient to handle 40K ups in ye sims.

Added a thread to handle txn completion, which will eventually be moved into CHOAM to prevent blockage of the Linear processing of the blocks.