### PR TITLE
fix/simplify ring comm/iteration. Fix append list sharding in ThothDHT

### DIFF
--- a/memberships/src/main/java/com/salesforce/apollo/membership/messaging/rbc/ReliableBroadcaster.java
+++ b/memberships/src/main/java/com/salesforce/apollo/membership/messaging/rbc/ReliableBroadcaster.java
@@ -154,7 +154,7 @@ public class ReliableBroadcaster {
             Member predecessor = context.ring(request.getRing()).predecessor(member);
             if (predecessor == null || !from.equals(predecessor.getId())) {
                 log.info("Invalid inbound messages gossip on {}:{} from: {} on ring: {} - not predecessor: {}",
-                         context.getId(), member, from, request.getRing(), predecessor);
+                         context.getId(), member.getId(), from, request.getRing(), predecessor.getId());
                 return Reconcile.getDefaultInstance();
             }
             return Reconcile.newBuilder()
@@ -167,7 +167,7 @@ public class ReliableBroadcaster {
             Member predecessor = context.ring(reconcile.getRing()).predecessor(member);
             if (predecessor == null || !from.equals(predecessor.getId())) {
                 log.info("Invalid inbound messages reconcile on {}:{} from: {} on ring: {} - not predecessor: {}",
-                         context.getId(), member, from, reconcile.getRing(), predecessor);
+                         context.getId(), member.getId(), from, reconcile.getRing(), predecessor.getId());
                 return;
             }
             buffer.receive(reconcile.getUpdatesList());
@@ -427,7 +427,7 @@ public class ReliableBroadcaster {
         if (!started.get()) {
             return;
         }
-        log.debug("publishing message on: {}", member);
+        log.debug("publishing message on: {}", member.getId());
         AgedMessage m = buffer.send(message, member);
         if (notifyLocal) {
             deliver(Collections.singletonList(new Msg(member.getId(), m.getContent(),
@@ -501,7 +501,8 @@ public class ReliableBroadcaster {
         if (!started.get()) {
             return null;
         }
-        log.trace("rbc gossiping[{}] from {} with {} on {}", buffer.round(), member, link.getMember(), ring);
+        log.trace("rbc gossiping[{}] from {} with {} on {}", buffer.round(), member.getId(), link.getMember().getId(),
+                  ring);
         try {
             return link.gossip(MessageBff.newBuilder()
                                          .setContext(context.getId().toDigeste())

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <jackson.version>2.13.2</jackson.version>
         <dropwizard.version>2.0.28</dropwizard.version>
         <h2.version>2.1.212</h2.version>
-        <jooq.version>3.16.6</jooq.version>
+        <jooq.version>3.17.2</jooq.version>
         <bc.version>1.71</bc.version>
         <logback.version>1.2.11</logback.version>
         <grpc.version>1.48.0</grpc.version>

--- a/thoth/pom.xml
+++ b/thoth/pom.xml
@@ -30,14 +30,6 @@
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
         </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-        </dependency>
 
 
         <!-- Test only deps below this line -->

--- a/thoth/src/test/java/com/salesforce/apollo/thoth/AbstractDhtTest.java
+++ b/thoth/src/test/java/com/salesforce/apollo/thoth/AbstractDhtTest.java
@@ -56,7 +56,7 @@ import com.salesforce.apollo.stereotomy.mem.MemKeyStore;
 public class AbstractDhtTest {
     protected static final ProtobufEventFactory factory = new ProtobufEventFactory();
 
-    protected static final double                                                PBYZ    = 0.2;
+    protected static final double                                                PBYZ    = 0.33;
     protected final Map<SigningMember, KerlDHT>                                  dhts    = new HashMap<>();
     protected Map<SigningMember, ControlledIdentifier<SelfAddressingIdentifier>> identities;
     protected int                                                                majority;
@@ -90,11 +90,7 @@ public class AbstractDhtTest {
                               .collect(Collectors.toMap(controlled -> new ControlledIdentifierMember(controlled),
                                                         controlled -> controlled));
         String prefix = UUID.randomUUID().toString();
-        Context<Member> context = Context.<Member>newBuilder()
-                                         .setpByz(PBYZ)
-                                         .setCardinality(getCardinality())
-                                         .setBias(3)
-                                         .build();
+        Context<Member> context = Context.<Member>newBuilder().setpByz(PBYZ).setCardinality(getCardinality()).build();
         majority = context.majority();
         identities.keySet().forEach(member -> instantiate(member, context, prefix));
 


### PR DESCRIPTION
Geebus.  That was a subtle bug.

The previous version(s) would calculate "traversed" from a random
ordering each time.  Not useful.

Fix is to calc pred/succ once and then randomly permute that list.