### PR TITLE
rpc context cleanup

### DIFF
--- a/choam/src/main/java/com/salesforce/apollo/choam/Committee.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/Committee.java
@@ -16,11 +16,9 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 import com.salesfoce.apollo.choam.proto.Certification;
-import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Reconfigure;
 import com.salesfoce.apollo.choam.proto.SubmitResult;
 import com.salesfoce.apollo.choam.proto.SubmitResult.Result;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
 import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesforce.apollo.choam.support.HashedCertifiedBlock;
@@ -79,7 +77,7 @@ public interface Committee {
 
     boolean isMember();
 
-    ViewMember join(JoinRequest request, Digest from);
+    ViewMember join(Digest nextView, Digest from);
 
     Logger log();
 
@@ -89,7 +87,7 @@ public interface Committee {
         throw new IllegalStateException("Should not be called on this implementation");
     }
 
-    default SubmitResult submit(SubmitTransaction request) {
+    default SubmitResult submit(Transaction request) {
         log().debug("Cannot submit txn, inactive committee: {} on: {}", getClass().getSimpleName(),
                     params().member().getId());
         return SubmitResult.newBuilder().setResult(Result.INACTIVE).build();

--- a/choam/src/main/java/com/salesforce/apollo/choam/ViewAssembly.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/ViewAssembly.java
@@ -32,7 +32,6 @@ import com.chiralbehaviors.tron.Fsm;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.salesfoce.apollo.choam.proto.Certification;
 import com.salesfoce.apollo.choam.proto.Join;
-import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Reassemble;
 import com.salesfoce.apollo.choam.proto.Validate;
 import com.salesfoce.apollo.choam.proto.ViewMember;
@@ -117,10 +116,6 @@ public class ViewAssembly {
         @Override
         public void gather() {
             log.trace("Gathering assembly for: {} on: {}", nextViewId, params().member());
-            JoinRequest request = JoinRequest.newBuilder()
-                                             .setContext(params().context().getId().toDigeste())
-                                             .setNextView(nextViewId.toDigeste())
-                                             .build();
             AtomicReference<Runnable> reiterate = new AtomicReference<>();
             AtomicReference<Duration> retryDelay = new AtomicReference<>(Duration.ofMillis(10));
             reiterate.set(() -> committee.iterate((term, m) -> {
@@ -128,7 +123,7 @@ public class ViewAssembly {
                     return null;
                 }
                 log.trace("Requesting Join from: {} on: {}", term.getMember().getId(), params().member().getId());
-                return term.join(request);
+                return term.join(nextViewId);
             }, (futureSailor, term, m) -> consider(futureSailor, term, m), () -> completeSlice(retryDelay, reiterate),
                                                   params().scheduler(), params().gossipDuration()));
             reiterate.get().run();

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/Concierge.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/Concierge.java
@@ -11,7 +11,6 @@ import com.salesfoce.apollo.choam.proto.Blocks;
 import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
-import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesforce.apollo.crypto.Digest;
@@ -28,7 +27,7 @@ public interface Concierge {
 
     Blocks fetchViewChain(BlockReplication request, Digest from);
 
-    ViewMember join(JoinRequest request, Digest from);
+    ViewMember join(Digest nextView, Digest from);
 
     Initial sync(Synchronize request, Digest from);
 

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/Submitter.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/Submitter.java
@@ -7,7 +7,7 @@
 package com.salesforce.apollo.choam.comm;
 
 import com.salesfoce.apollo.choam.proto.SubmitResult;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
+import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesforce.apollo.crypto.Digest;
 
 /**
@@ -16,6 +16,6 @@ import com.salesforce.apollo.crypto.Digest;
  */
 public interface Submitter {
 
-    SubmitResult submit(SubmitTransaction request, Digest from);
+    SubmitResult submit(Transaction request, Digest from);
 
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/Terminal.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/Terminal.java
@@ -13,10 +13,10 @@ import com.salesfoce.apollo.choam.proto.Blocks;
 import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
-import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesforce.apollo.archipelago.Link;
+import com.salesforce.apollo.crypto.Digest;
 import com.salesforce.apollo.membership.Member;
 import com.salesforce.apollo.membership.SigningMember;
 
@@ -56,9 +56,9 @@ public interface Terminal extends Link {
             }
 
             @Override
-            public ListenableFuture<ViewMember> join(JoinRequest join) {
+            public ListenableFuture<ViewMember> join(Digest nextView) {
                 SettableFuture<ViewMember> f = SettableFuture.create();
-                f.set(service.join(join, member.getId()));
+                f.set(service.join(nextView, member.getId()));
                 return f;
             }
 
@@ -75,7 +75,7 @@ public interface Terminal extends Link {
 
     ListenableFuture<Blocks> fetchViewChain(BlockReplication replication);
 
-    ListenableFuture<ViewMember> join(JoinRequest join);
+    ListenableFuture<ViewMember> join(Digest nextView);
 
     ListenableFuture<Initial> sync(Synchronize sync);
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TerminalClient.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TerminalClient.java
@@ -12,7 +12,6 @@ import com.salesfoce.apollo.choam.proto.Blocks;
 import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
-import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.TerminalGrpc;
 import com.salesfoce.apollo.choam.proto.TerminalGrpc.TerminalFutureStub;
@@ -20,6 +19,7 @@ import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesforce.apollo.archipelago.ManagedServerChannel;
 import com.salesforce.apollo.archipelago.ServerConnectionCache.CreateClientCommunications;
 import com.salesforce.apollo.choam.support.ChoamMetrics;
+import com.salesforce.apollo.crypto.Digest;
 import com.salesforce.apollo.membership.Member;
 
 /**
@@ -71,8 +71,8 @@ public class TerminalClient implements Terminal {
     }
 
     @Override
-    public ListenableFuture<ViewMember> join(JoinRequest join) {
-        return client.join(join);
+    public ListenableFuture<ViewMember> join(Digest nextView) {
+        return client.join(nextView.toDigeste());
     }
 
     public void release() {

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TerminalServer.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TerminalServer.java
@@ -11,10 +11,10 @@ import com.salesfoce.apollo.choam.proto.Blocks;
 import com.salesfoce.apollo.choam.proto.CheckpointReplication;
 import com.salesfoce.apollo.choam.proto.CheckpointSegments;
 import com.salesfoce.apollo.choam.proto.Initial;
-import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Synchronize;
 import com.salesfoce.apollo.choam.proto.TerminalGrpc.TerminalImplBase;
 import com.salesfoce.apollo.choam.proto.ViewMember;
+import com.salesfoce.apollo.utils.proto.Digeste;
 import com.salesforce.apollo.archipelago.RoutableService;
 import com.salesforce.apollo.choam.support.ChoamMetrics;
 import com.salesforce.apollo.crypto.Digest;
@@ -78,14 +78,14 @@ public class TerminalServer extends TerminalImplBase {
     }
 
     @Override
-    public void join(JoinRequest request, StreamObserver<ViewMember> responseObserver) {
+    public void join(Digeste nextView, StreamObserver<ViewMember> responseObserver) {
         Digest from = identity.getFrom();
         if (from == null) {
             responseObserver.onError(new IllegalStateException("Member has been removed"));
             return;
         }
         router.evaluate(responseObserver, s -> {
-            responseObserver.onNext(s.join(request, from));
+            responseObserver.onNext(s.join(Digest.from(nextView), from));
             responseObserver.onCompleted();
         });
     }

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmission.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmission.java
@@ -9,7 +9,7 @@ package com.salesforce.apollo.choam.comm;
 import java.io.IOException;
 
 import com.salesfoce.apollo.choam.proto.SubmitResult;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
+import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesforce.apollo.archipelago.Link;
 import com.salesforce.apollo.membership.Member;
 import com.salesforce.apollo.membership.SigningMember;
@@ -33,11 +33,11 @@ public interface TxnSubmission extends Link {
             }
 
             @Override
-            public SubmitResult submit(SubmitTransaction request) {
+            public SubmitResult submit(Transaction request) {
                 return service.submit(request, member.getId());
             }
         };
     }
 
-    SubmitResult submit(SubmitTransaction request);
+    SubmitResult submit(Transaction request);
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitClient.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitClient.java
@@ -7,7 +7,7 @@
 package com.salesforce.apollo.choam.comm;
 
 import com.salesfoce.apollo.choam.proto.SubmitResult;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
+import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesfoce.apollo.choam.proto.TransactionSubmissionGrpc;
 import com.salesfoce.apollo.choam.proto.TransactionSubmissionGrpc.TransactionSubmissionBlockingStub;
 import com.salesforce.apollo.archipelago.ManagedServerChannel;
@@ -50,7 +50,7 @@ public class TxnSubmitClient implements TxnSubmission {
     }
 
     @Override
-    public SubmitResult submit(SubmitTransaction request) {
+    public SubmitResult submit(Transaction request) {
         return client.submit(request);
     }
 }

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitServer.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitServer.java
@@ -7,7 +7,7 @@
 package com.salesforce.apollo.choam.comm;
 
 import com.salesfoce.apollo.choam.proto.SubmitResult;
-import com.salesfoce.apollo.choam.proto.SubmitTransaction;
+import com.salesfoce.apollo.choam.proto.Transaction;
 import com.salesfoce.apollo.choam.proto.TransactionSubmissionGrpc.TransactionSubmissionImplBase;
 import com.salesforce.apollo.archipelago.RoutableService;
 import com.salesforce.apollo.choam.support.ChoamMetrics;
@@ -34,7 +34,7 @@ public class TxnSubmitServer extends TransactionSubmissionImplBase {
     }
 
     @Override
-    public void submit(SubmitTransaction request, StreamObserver<SubmitResult> responseObserver) {
+    public void submit(Transaction request, StreamObserver<SubmitResult> responseObserver) {
         Digest from = identity.getFrom();
         if (from == null) {
             responseObserver.onError(new IllegalStateException("Member has been removed"));

--- a/choam/src/main/java/com/salesforce/apollo/choam/support/Bootstrapper.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/support/Bootstrapper.java
@@ -135,7 +135,6 @@ public class Bootstrapper {
         start.set(store.firstGap(start.get(), end));
         store.blocksFrom(start.get(), end, params.bootstrap().maxSyncBlocks()).forEachRemaining(h -> blocksBff.add(h));
         BlockReplication replication = BlockReplication.newBuilder()
-                                                       .setContext(params.context().getId().toDigeste())
                                                        .setBlocksBff(blocksBff.toBff())
                                                        .setFrom(start.get().longValue())
                                                        .setTo(end.longValue())
@@ -266,7 +265,6 @@ public class Bootstrapper {
         start.set(store.lastViewChainFrom(start.get()));
         store.viewChainFrom(start.get(), end).forEachRemaining(h -> blocksBff.add(h));
         BlockReplication replication = BlockReplication.newBuilder()
-                                                       .setContext(params.context().getId().toDigeste())
                                                        .setBlocksBff(blocksBff.toBff())
                                                        .setFrom(start.get().longValue())
                                                        .setTo(end.longValue())
@@ -411,10 +409,7 @@ public class Bootstrapper {
             return;
         }
         HashMap<Digest, Initial> votes = new HashMap<>();
-        Synchronize s = Synchronize.newBuilder()
-                                   .setContext(params.context().getId().toDigeste())
-                                   .setHeight(anchor.height().longValue())
-                                   .build();
+        Synchronize s = Synchronize.newBuilder().setHeight(anchor.height().longValue()).build();
         final var randomCut = randomCut(params.digestAlgorithm());
         new RingIterator<>(params.gossipDuration(), params.context(), params.member(), comms, params.exec(), true,
                            params.scheduler()).iterate(randomCut, (link, ring) -> synchronize(s, link),

--- a/choam/src/main/java/com/salesforce/apollo/choam/support/CheckpointAssembler.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/support/CheckpointAssembler.java
@@ -92,11 +92,10 @@ public class CheckpointAssembler {
         IntStream.range(0, checkpoint.getSegmentsCount()).filter(i -> state.containsKey(i)).forEach(i -> {
             segmentsBff.add(i);
         });
-        CheckpointReplication.Builder request = CheckpointReplication.newBuilder()
-                                                                     .setContext(context.getId().toDigeste())
-                                                                     .setCheckpoint(height.longValue());
-        request.setCheckpointSegments(segmentsBff.toBff());
-        return request.build();
+        return CheckpointReplication.newBuilder()
+                                    .setCheckpoint(height.longValue())
+                                    .setCheckpointSegments(segmentsBff.toBff())
+                                    .build();
     }
 
     private boolean gossip(Optional<ListenableFuture<CheckpointSegments>> futureSailor) {

--- a/choam/src/test/java/com/salesforce/apollo/choam/GenesisAssemblyTest.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/GenesisAssemblyTest.java
@@ -37,7 +37,6 @@ import com.salesfoce.apollo.choam.proto.Block;
 import com.salesfoce.apollo.choam.proto.CertifiedBlock;
 import com.salesfoce.apollo.choam.proto.Executions;
 import com.salesfoce.apollo.choam.proto.Join;
-import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesfoce.apollo.utils.proto.PubKey;
 import com.salesforce.apollo.archipelago.LocalServer;
@@ -105,7 +104,7 @@ public class GenesisAssemblyTest {
         Map<Member, Concierge> servers = members.stream().collect(Collectors.toMap(m -> m, m -> mock(Concierge.class)));
 
         servers.forEach((m, s) -> {
-            when(s.join(any(JoinRequest.class), any(Digest.class))).then(new Answer<ViewMember>() {
+            when(s.join(any(Digest.class), any(Digest.class))).then(new Answer<ViewMember>() {
                 @Override
                 public ViewMember answer(InvocationOnMock invocation) throws Throwable {
                     KeyPair keyPair = params.getViewSigAlgorithm().generateKeyPair();

--- a/choam/src/test/java/com/salesforce/apollo/choam/ViewAssemblyTest.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/ViewAssemblyTest.java
@@ -31,7 +31,6 @@ import org.mockito.stubbing.Answer;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import com.salesfoce.apollo.choam.proto.JoinRequest;
 import com.salesfoce.apollo.choam.proto.Reassemble;
 import com.salesfoce.apollo.choam.proto.ViewMember;
 import com.salesfoce.apollo.utils.proto.PubKey;
@@ -172,7 +171,7 @@ public class ViewAssemblyTest {
             KeyPair keyPair = params.getViewSigAlgorithm().generateKeyPair();
             consensusPairs.put(m, keyPair);
             final PubKey consensus = QualifiedBase64.bs(keyPair.getPublic());
-            when(s.join(any(JoinRequest.class), any(Digest.class))).then(new Answer<ViewMember>() {
+            when(s.join(any(Digest.class), any(Digest.class))).then(new Answer<ViewMember>() {
                 @Override
                 public ViewMember answer(InvocationOnMock invocation) throws Throwable {
                     return ViewMember.newBuilder()

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/Ethereal.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/Ethereal.java
@@ -194,7 +194,7 @@ public class Ethereal {
         return new Processor() {
             @Override
             public Gossip gossip(Digest context, int ring) {
-                final var builder = Gossip.newBuilder().setContext(context.toDigeste()).setRing(ring);
+                final var builder = Gossip.newBuilder().setRing(ring);
                 final var current = currentEpoch.get();
                 epochs.entrySet()
                       .stream()

--- a/ethereal/src/main/java/com/salesforce/apollo/ethereal/memberships/ChRbcGossip.java
+++ b/ethereal/src/main/java/com/salesforce/apollo/ethereal/memberships/ChRbcGossip.java
@@ -214,7 +214,6 @@ public class ChRbcGossip {
             log.trace("gossip update with {} on: {}", destination.member(), member);
             destination.link()
                        .update(ContextUpdate.newBuilder()
-                                            .setContext(context.getId().toDigeste())
                                             .setRing(destination.ring())
                                             .setUpdate(processor.update(update))
                                             .build());

--- a/fireflies/src/main/java/com/salesforce/apollo/fireflies/Binding.java
+++ b/fireflies/src/main/java/com/salesforce/apollo/fireflies/Binding.java
@@ -264,11 +264,7 @@ class Binding {
     }
 
     private Join join(Digest v) {
-        return Join.newBuilder()
-                   .setContext(context.getId().toDigeste())
-                   .setView(v.toDigeste())
-                   .setNote(node.getNote().getWrapped())
-                   .build();
+        return Join.newBuilder().setView(v.toDigeste()).setNote(node.getNote().getWrapped()).build();
     }
 
     private BiConsumer<? super Redirect, ? super Throwable> join(Duration duration, ScheduledExecutorService scheduler,
@@ -357,7 +353,6 @@ class Binding {
 
     private Registration registration() {
         return Registration.newBuilder()
-                           .setContext(context.getId().toDigeste())
                            .setView(view.bootstrapView().toDigeste())
                            .setKerl(node.kerl())
                            .setNote(node.note.getWrapped())

--- a/fireflies/src/main/java/com/salesforce/apollo/fireflies/View.java
+++ b/fireflies/src/main/java/com/salesforce/apollo/fireflies/View.java
@@ -1569,7 +1569,6 @@ public class View {
         }
 
         final SayWhat gossip = stable(() -> SayWhat.newBuilder()
-                                                   .setContext(context.getId().toDigeste())
                                                    .setView(currentView().toDigeste())
                                                    .setNote(node.getNote().getWrapped())
                                                    .setRing(ring)
@@ -1642,7 +1641,6 @@ public class View {
                                       update.getObservationsCount(), node.getId());
                             destination.link()
                                        .update(State.newBuilder()
-                                                    .setContext(context.getId().toDigeste())
                                                     .setView(currentView().toDigeste())
                                                     .setRing(destination.ring())
                                                     .setUpdate(update)

--- a/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/admissions/Admissions.java
+++ b/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/admissions/Admissions.java
@@ -10,10 +10,10 @@ import java.io.IOException;
 import java.time.Duration;
 
 import com.google.common.util.concurrent.ListenableFuture;
-import com.salesfoce.apollo.gorgoneion.proto.Application;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
 import com.salesfoce.apollo.gorgoneion.proto.Invitation;
 import com.salesfoce.apollo.gorgoneion.proto.SignedNonce;
+import com.salesfoce.apollo.stereotomy.event.proto.KERL_;
 import com.salesforce.apollo.archipelago.Link;
 import com.salesforce.apollo.membership.Member;
 
@@ -27,7 +27,7 @@ public interface Admissions extends Link {
         return new Admissions() {
 
             @Override
-            public ListenableFuture<SignedNonce> apply(Application application, Duration timeout) {
+            public ListenableFuture<SignedNonce> apply(KERL_ application, Duration timeout) {
                 return null;
             }
 
@@ -47,7 +47,7 @@ public interface Admissions extends Link {
         };
     }
 
-    ListenableFuture<SignedNonce> apply(Application application, Duration timeout);
+    ListenableFuture<SignedNonce> apply(KERL_ application, Duration timeout);
 
     ListenableFuture<Invitation> register(Credentials credentials, Duration timeout);
 }

--- a/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/admissions/AdmissionsClient.java
+++ b/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/admissions/AdmissionsClient.java
@@ -12,10 +12,10 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.salesfoce.apollo.gorgoneion.proto.AdmissionsGrpc;
 import com.salesfoce.apollo.gorgoneion.proto.AdmissionsGrpc.AdmissionsFutureStub;
-import com.salesfoce.apollo.gorgoneion.proto.Application;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
 import com.salesfoce.apollo.gorgoneion.proto.Invitation;
 import com.salesfoce.apollo.gorgoneion.proto.SignedNonce;
+import com.salesfoce.apollo.stereotomy.event.proto.KERL_;
 import com.salesforce.apollo.archipelago.ManagedServerChannel;
 import com.salesforce.apollo.archipelago.ServerConnectionCache.CreateClientCommunications;
 import com.salesforce.apollo.gorgoneion.comm.GorgoneionMetrics;
@@ -43,7 +43,7 @@ public class AdmissionsClient implements Admissions {
     }
 
     @Override
-    public ListenableFuture<SignedNonce> apply(Application application, Duration timeout) {
+    public ListenableFuture<SignedNonce> apply(KERL_ application, Duration timeout) {
         if (metrics != null) {
             var serializedSize = application.getSerializedSize();
             metrics.outboundBandwidth().mark(serializedSize);

--- a/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/admissions/AdmissionsServer.java
+++ b/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/admissions/AdmissionsServer.java
@@ -7,10 +7,10 @@
 package com.salesforce.apollo.gorgoneion.comm.admissions;
 
 import com.salesfoce.apollo.gorgoneion.proto.AdmissionsGrpc.AdmissionsImplBase;
-import com.salesfoce.apollo.gorgoneion.proto.Application;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
 import com.salesfoce.apollo.gorgoneion.proto.Invitation;
 import com.salesfoce.apollo.gorgoneion.proto.SignedNonce;
+import com.salesfoce.apollo.stereotomy.event.proto.KERL_;
 import com.salesforce.apollo.archipelago.RoutableService;
 import com.salesforce.apollo.crypto.Digest;
 import com.salesforce.apollo.gorgoneion.comm.GorgoneionMetrics;
@@ -35,9 +35,9 @@ public class AdmissionsServer extends AdmissionsImplBase {
     }
 
     @Override
-    public void apply(Application request, StreamObserver<SignedNonce> responseObserver) {
+    public void apply(KERL_ application, StreamObserver<SignedNonce> responseObserver) {
         if (metrics != null) {
-            var serializedSize = request.getSerializedSize();
+            var serializedSize = application.getSerializedSize();
             metrics.inboundBandwidth().mark(serializedSize);
             metrics.inboundApplication().update(serializedSize);
         }
@@ -47,7 +47,7 @@ public class AdmissionsServer extends AdmissionsImplBase {
             return;
         }
         router.evaluate(responseObserver, s -> {
-            s.apply(request, from, responseObserver, null);
+            s.apply(application, from, responseObserver, null);
         });
     }
 

--- a/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/admissions/AdmissionsService.java
+++ b/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/admissions/AdmissionsService.java
@@ -7,10 +7,10 @@
 package com.salesforce.apollo.gorgoneion.comm.admissions;
 
 import com.codahale.metrics.Timer.Context;
-import com.salesfoce.apollo.gorgoneion.proto.Application;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
 import com.salesfoce.apollo.gorgoneion.proto.Invitation;
 import com.salesfoce.apollo.gorgoneion.proto.SignedNonce;
+import com.salesfoce.apollo.stereotomy.event.proto.KERL_;
 import com.salesforce.apollo.crypto.Digest;
 
 import io.grpc.stub.StreamObserver;
@@ -21,7 +21,7 @@ import io.grpc.stub.StreamObserver;
  */
 public interface AdmissionsService {
 
-    void apply(Application request, Digest from, StreamObserver<SignedNonce> responseObserver, Context timer);
+    void apply(KERL_ application, Digest from, StreamObserver<SignedNonce> responseObserver, Context timer);
 
     void register(Credentials request, Digest from, StreamObserver<Invitation> responseObserver, Context timer);
 

--- a/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/endorsement/Endorsement.java
+++ b/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/endorsement/Endorsement.java
@@ -13,7 +13,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.protobuf.Empty;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
-import com.salesfoce.apollo.gorgoneion.proto.EndorseNonce;
+import com.salesfoce.apollo.gorgoneion.proto.Nonce;
 import com.salesfoce.apollo.gorgoneion.proto.Notarization;
 import com.salesfoce.apollo.stereotomy.event.proto.Validation_;
 import com.salesforce.apollo.archipelago.Link;
@@ -32,7 +32,7 @@ public interface Endorsement extends Link {
             }
 
             @Override
-            public ListenableFuture<Validation_> endorse(EndorseNonce nonce, Duration timer) {
+            public ListenableFuture<Validation_> endorse(Nonce nonce, Duration timer) {
                 SettableFuture<Validation_> f = SettableFuture.create();
                 service.endorse(nonce, member.getId()).whenComplete((e, t) -> {
                     if (t != null) {
@@ -77,7 +77,7 @@ public interface Endorsement extends Link {
         };
     }
 
-    ListenableFuture<Validation_> endorse(EndorseNonce nonce, Duration timer);
+    ListenableFuture<Validation_> endorse(Nonce nonce, Duration timer);
 
     ListenableFuture<Empty> enroll(Notarization notarization, Duration timeout);
 

--- a/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/endorsement/EndorsementClient.java
+++ b/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/endorsement/EndorsementClient.java
@@ -13,9 +13,9 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Empty;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
-import com.salesfoce.apollo.gorgoneion.proto.EndorseNonce;
 import com.salesfoce.apollo.gorgoneion.proto.EndorsementGrpc;
 import com.salesfoce.apollo.gorgoneion.proto.EndorsementGrpc.EndorsementFutureStub;
+import com.salesfoce.apollo.gorgoneion.proto.Nonce;
 import com.salesfoce.apollo.gorgoneion.proto.Notarization;
 import com.salesfoce.apollo.stereotomy.event.proto.Validation_;
 import com.salesforce.apollo.archipelago.ManagedServerChannel;
@@ -50,7 +50,7 @@ public class EndorsementClient implements Endorsement {
     }
 
     @Override
-    public ListenableFuture<Validation_> endorse(EndorseNonce nonce, Duration timeout) {
+    public ListenableFuture<Validation_> endorse(Nonce nonce, Duration timeout) {
         if (metrics != null) {
             var serializedSize = nonce.getSerializedSize();
             metrics.outboundBandwidth().mark(serializedSize);

--- a/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/endorsement/EndorsementServer.java
+++ b/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/endorsement/EndorsementServer.java
@@ -8,8 +8,8 @@ package com.salesforce.apollo.gorgoneion.comm.endorsement;
 
 import com.google.protobuf.Empty;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
-import com.salesfoce.apollo.gorgoneion.proto.EndorseNonce;
 import com.salesfoce.apollo.gorgoneion.proto.EndorsementGrpc.EndorsementImplBase;
+import com.salesfoce.apollo.gorgoneion.proto.Nonce;
 import com.salesfoce.apollo.gorgoneion.proto.Notarization;
 import com.salesfoce.apollo.stereotomy.event.proto.Validation_;
 import com.salesforce.apollo.archipelago.RoutableService;
@@ -36,7 +36,7 @@ public class EndorsementServer extends EndorsementImplBase {
     }
 
     @Override
-    public void endorse(EndorseNonce request, StreamObserver<Validation_> responseObserver) {
+    public void endorse(Nonce request, StreamObserver<Validation_> responseObserver) {
         var timer = metrics == null ? null : metrics.registerDuration().time();
         if (metrics != null) {
             var serializedSize = request.getSerializedSize();

--- a/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/endorsement/EndorsementService.java
+++ b/gorgoneion/src/main/java/com/salesforce/apollo/gorgoneion/comm/endorsement/EndorsementService.java
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 import com.google.protobuf.Empty;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
-import com.salesfoce.apollo.gorgoneion.proto.EndorseNonce;
+import com.salesfoce.apollo.gorgoneion.proto.Nonce;
 import com.salesfoce.apollo.gorgoneion.proto.Notarization;
 import com.salesfoce.apollo.stereotomy.event.proto.Validation_;
 import com.salesforce.apollo.crypto.Digest;
@@ -21,7 +21,7 @@ import com.salesforce.apollo.crypto.Digest;
  */
 public interface EndorsementService {
 
-    CompletableFuture<Validation_> endorse(EndorseNonce request, Digest from);
+    CompletableFuture<Validation_> endorse(Nonce request, Digest from);
 
     CompletableFuture<Empty> enroll(Notarization request, Digest from);
 

--- a/gorgoneion/src/test/java/com/salesforce/apollo/gorgoneion/GorgoneionTest.java
+++ b/gorgoneion/src/test/java/com/salesforce/apollo/gorgoneion/GorgoneionTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
-import com.salesfoce.apollo.gorgoneion.proto.Application;
 import com.salesfoce.apollo.gorgoneion.proto.Attestation;
 import com.salesfoce.apollo.gorgoneion.proto.Credentials;
 import com.salesfoce.apollo.gorgoneion.proto.Invitation;
@@ -107,7 +106,7 @@ public class GorgoneionTest {
             return fs;
         };
 
-        var gorgoneionClient = new GorgoneionClient(client, context.getId(), attester, parameters.clock(), admin);
+        var gorgoneionClient = new GorgoneionClient(client, attester, parameters.clock(), admin);
 
         Invitation invitation = gorgoneionClient.apply(Duration.ofSeconds(2)).get(3, TimeUnit.SECONDS);
         assertNotNull(invitation);
@@ -176,7 +175,7 @@ public class GorgoneionTest {
             return fs;
         };
 
-        var gorgoneionClient = new GorgoneionClient(client, context.getId(), attester, parameters.clock(), admin);
+        var gorgoneionClient = new GorgoneionClient(client, attester, parameters.clock(), admin);
 
         final var apply = gorgoneionClient.apply(Duration.ofSeconds(2));
         Invitation invitation = apply.get(3, TimeUnit.SECONDS);
@@ -232,11 +231,7 @@ public class GorgoneionTest {
         // Apply for registration of the client's KERL, receiving the signed nonce from
         // the server
         final KERL_ kerl = client.kerl().get();
-        ListenableFuture<SignedNonce> fs = admin.apply(Application.newBuilder()
-                                                                  .setContext(context.getId().toDigeste())
-                                                                  .setKerl(kerl)
-                                                                  .build(),
-                                                       Duration.ofSeconds(1));
+        ListenableFuture<SignedNonce> fs = admin.apply(kerl, Duration.ofSeconds(1));
         assertNotNull(fs);
         var signedNonce = fs.get();
         assertNotNull(signedNonce.getNonce());
@@ -256,7 +251,6 @@ public class GorgoneionTest {
                                            .build();
 
         Invitation invitation = admin.register(Credentials.newBuilder()
-                                                          .setContext(context.getId().toDigeste())
                                                           .setAttestation(SignedAttestation.newBuilder()
                                                                                            .setAttestation(attestation)
                                                                                            .setSignature(client.sign(attestation.toByteString())

--- a/grpc/src/main/proto/choam.proto
+++ b/grpc/src/main/proto/choam.proto
@@ -10,28 +10,18 @@ import "stereotomy.proto";
 package apollo.choam;
 
 service TransactionSubmission {
-    rpc submit (SubmitTransaction) returns (SubmitResult) {}
+    rpc submit (Transaction) returns (SubmitResult) {}
 }
 
 service Terminal {
     /* reconfiguration */
-    rpc join (JoinRequest) returns (ViewMember) {}
+    rpc join (utils.Digeste) returns (ViewMember) {}
 
     /* bootstrapping */
     rpc sync(Synchronize) returns (Initial) {}
     rpc fetchBlocks(BlockReplication) returns (Blocks) {}
     rpc fetchViewChain(BlockReplication) returns (Blocks) {}
     rpc fetch(CheckpointReplication) returns (CheckpointSegments) {}
-}
-
-message JoinRequest {
-    utils.Digeste context = 1;
-    utils.Digeste nextView = 2;
-}
-
-message SubmitTransaction {
-    utils.Digeste context = 1;
-    Transaction transaction = 2;
 }
 
 message SubmitResult {
@@ -174,9 +164,8 @@ message Validations {
 }
 
 message Synchronize {
-    utils.Digeste context = 1;
-    utils.Digeste from = 2;
-    uint64 height = 3;
+    utils.Digeste from = 1;
+    uint64 height = 2;
 }
 
 message Initial {
@@ -187,10 +176,9 @@ message Initial {
 }
 
 message BlockReplication {
-    utils.Digeste context = 1;
-    uint64 from = 2;
-    uint64 to = 3;
-    utils.Biff blocksBff = 4;
+    uint64 from = 1;
+    uint64 to = 2;
+    utils.Biff blocksBff = 3;
 }
 
 message Blocks {
@@ -198,9 +186,8 @@ message Blocks {
 }
 
 message CheckpointReplication {
-    utils.Digeste context = 1;
-    uint64 checkpoint = 2;
-    utils.Biff checkpointSegments = 3;
+    uint64 checkpoint = 1;
+    utils.Biff checkpointSegments = 2;
 }
 
 message CheckpointSegments {

--- a/grpc/src/main/proto/ethereal.proto
+++ b/grpc/src/main/proto/ethereal.proto
@@ -15,10 +15,9 @@ service Gossiper {
 }
 
 message Gossip {
-    utils.Digeste context = 1;
-    int32 ring = 2;
-    utils.Biff have = 3;
-    repeated Have haves = 4;
+    int32 ring = 1;
+    utils.Biff have = 2;
+    repeated Have haves = 3;
 }
 
 message Have {
@@ -43,10 +42,9 @@ message Update {
     repeated Missing missings = 4;
 }
 
-message ContextUpdate {
-    utils.Digeste context = 1;
-    int32 ring = 2;
-    Update update = 3;
+message ContextUpdate { 
+    int32 ring = 1;
+    Update update = 2;
 }
 
 message PreVote {

--- a/grpc/src/main/proto/fireflies.proto
+++ b/grpc/src/main/proto/fireflies.proto
@@ -17,19 +17,17 @@ service Fireflies {
     rpc update (State) returns (google.protobuf.Empty) {}
 }
 
-message SayWhat {
-    utils.Digeste context = 1;
-    utils.Digeste view = 2;
-    SignedNote note = 3;
-    int32 ring = 4;
-    Digests gossip = 5;
+message SayWhat { 
+    utils.Digeste view = 1;
+    SignedNote note = 2;
+    int32 ring = 3;
+    Digests gossip = 4;
 }
 
-message State {
-    utils.Digeste context = 1;
-    utils.Digeste view = 2;
-    int32 ring = 3;
-    Update update = 4;
+message State { 
+    utils.Digeste view = 1;
+    int32 ring = 2;
+    Update update = 3;
 }
 
 message Accusation {
@@ -121,11 +119,10 @@ service Entrance {
     rpc join (Join) returns (Gateway) {}
 }
 
-message Registration {
-    utils.Digeste context = 1;
-    utils.Digeste view = 2;
-    SignedNote note = 3;
-    stereotomy.KERL_ kerl = 4;
+message Registration { 
+    utils.Digeste view = 1;
+    SignedNote note = 2;
+    stereotomy.KERL_ kerl = 3;
 }
 
 message Redirect {
@@ -141,10 +138,9 @@ message Seed_ {
     stereotomy.KeyState_ keyState = 5;
 }
 
-message Join {
-    utils.Digeste context = 1;
-    utils.Digeste view = 2;
-    SignedNote note = 3;
+message Join { 
+    utils.Digeste view = 1;
+    SignedNote note = 2;
 }
 
 message Gateway { 

--- a/grpc/src/main/proto/gorgoneion.proto
+++ b/grpc/src/main/proto/gorgoneion.proto
@@ -15,29 +15,19 @@ import "util.proto";
 package gorgoneion;
 
 service Admissions {
-    rpc apply (Application) returns (SignedNonce) {}
+    rpc apply (stereotomy.KERL_) returns (SignedNonce) {}
     rpc register (Credentials) returns (Invitation) {}
 }
 
 service Endorsement {
-    rpc endorse (EndorseNonce)returns (stereotomy.Validation_) {}
+    rpc endorse (Nonce)returns (stereotomy.Validation_) {}
     rpc validate (Credentials)returns (stereotomy.Validation_) {}
     rpc enroll (Notarization) returns (google.protobuf.Empty) {}
-}
-
-message Application {
-    utils.Digeste context = 1;
-    stereotomy.KERL_ kerl = 2;
 }
 
 message SignedNonce {
     Nonce nonce = 1;
     repeated stereotomy.Validation_ signatures = 2;
-}
-
-message EndorseNonce {
-    utils.Digeste context = 1;
-    Nonce nonce = 2;
 }
 
 message Nonce {
@@ -47,10 +37,9 @@ message Nonce {
     google.protobuf.Timestamp timestamp = 4;
 }
 
-message Credentials {
-    utils.Digeste context = 1; 
-    SignedNonce nonce = 2;
-    SignedAttestation attestation = 3;
+message Credentials { 
+    SignedNonce nonce = 1;
+    SignedAttestation attestation = 2;
 }
 
 message Invitation {
@@ -69,8 +58,7 @@ message SignedAttestation {
     utils.Sig signature = 2;
 }
 
-message Notarization { 
-    utils.Digeste context = 1;
-    stereotomy.KERL_ kerl = 2; 
-    stereotomy.Validations validations = 3;
+message Notarization {
+    stereotomy.KERL_ kerl = 1; 
+    stereotomy.Validations validations = 2;
 }

--- a/grpc/src/main/proto/messaging.proto
+++ b/grpc/src/main/proto/messaging.proto
@@ -9,10 +9,9 @@ import "util.proto";
 
 package messaging; 
 
-message MessageBff {
-    utils.Digeste context = 1; 
-    int32 ring = 3;
-    utils.Biff digests = 4;
+message MessageBff { 
+    int32 ring = 1;
+    utils.Biff digests = 2;
 }
 
 message ByteMessage {
@@ -29,10 +28,9 @@ message Reconcile {
     utils.Biff digests = 2;
 }
 
-message ReconcileContext {
-    utils.Digeste context = 1;
-    int32 ring = 2;
-    repeated  AgedMessage updates = 3;
+message ReconcileContext { 
+    int32 ring = 1;
+    repeated  AgedMessage updates = 2;
 }
 
 message AgedMessage {

--- a/grpc/src/main/proto/stereotomy-services.proto
+++ b/grpc/src/main/proto/stereotomy-services.proto
@@ -9,66 +9,34 @@ import "google/protobuf/empty.proto";
 import "util.proto";
 import "stereotomy.proto";
 
-package stereotomy.services;
-
-// Context routing for Resolver
-
-message IdentifierContext {
-    utils.Digeste context = 1;
-    stereotomy.Ident identifier = 2;
-}
-
-message EventContext {
-    utils.Digeste context = 1;
-    stereotomy.EventCoords coordinates = 2;
-}
-
-message KeyContext {
-    utils.Digeste context = 1;
-    stereotomy.KeyCoords coordinates = 2;
-}
-
-message EventDigestContext {
-    utils.Digeste context = 1;
-    utils.Digeste digest = 2;
-}
+package stereotomy.services; 
 
 message KeyStates {
     repeated KeyState_ keyStates = 1;
 }
 
 message AttachmentsContext {
-    utils.Digeste context = 1;
-    repeated AttachmentEvent attachments = 2;
+    repeated AttachmentEvent attachments = 1;
 }
 
 message KERLContext {
-    utils.Digeste context = 1;
-    stereotomy.KERL_ kerl = 2;
-    repeated stereotomy.Validations validations = 3;
-}
-
-message BindContext {
-    utils.Digeste context = 1;
-    stereotomy.Binding binding = 2;
+    stereotomy.KERL_ kerl = 1;
+    repeated stereotomy.Validations validations = 2;
 }
 
 message KeyEventContext {
-    utils.Digeste context = 1;
-    KeyEvent_ keyEvent = 2;
-    Validations validations = 3;
+    KeyEvent_ keyEvent = 1;
+    Validations validations = 2;
 }
 
 message KeyEventsContext {
-    utils.Digeste context = 1;
-    repeated KeyEvent_ keyEvent = 2;
-    repeated stereotomy.Validations validations = 3;
+    repeated KeyEvent_ keyEvent = 1;
+    repeated stereotomy.Validations validations = 2;
 }
 
 message KeyEventWithAttachmentsContext {
-    utils.Digeste context = 1;
-    repeated KeyEvent_ events = 2;
-    repeated AttachmentEvent attachments = 3;
+    repeated KeyEvent_ events = 1;
+    repeated AttachmentEvent attachments = 2;
 }
 
 message AttachmentEvents { 
@@ -80,22 +48,17 @@ service KERLService {
     rpc appendKERL (KERLContext) returns(KeyStates) {}
     rpc appendWithAttachments (KeyEventWithAttachmentsContext) returns(KeyStates) {}
     rpc appendAttachments (AttachmentsContext) returns(google.protobuf.Empty) {}
-    rpc appendValidations (ValidationsContext) returns (google.protobuf.Empty) {}
+    rpc appendValidations (stereotomy.Validations ) returns (google.protobuf.Empty) {}
 
-    rpc getAttachment (EventContext) returns(Attachment) {}
-    rpc getKeyEvent (EventDigestContext) returns(KeyEvent_) {}
-    rpc getKeyEventCoords (EventContext) returns(KeyEvent_) {}
-    rpc getKeyState (IdentifierContext) returns (stereotomy.KeyState_) {}
-    rpc getKeyStateCoords (EventContext) returns (stereotomy.KeyState_) {}
-    rpc getKeyStateWithAttachments (EventContext) returns (stereotomy.KeyStateWithAttachments_) {}
-    rpc getKeyStateWithEndorsementsAndValidations (EventContext) returns (stereotomy.KeyStateWithEndorsementsAndValidations_) {}
-    rpc getKERL (IdentifierContext) returns (stereotomy.KERL_) {}
-    rpc getValidations (EventContext) returns (stereotomy.Validations) {}
-}
-
-message ValidationsContext {
-    utils.Digeste context = 1;
-    stereotomy.Validations validations = 2;
+    rpc getAttachment (stereotomy.EventCoords) returns(Attachment) {}
+    rpc getKeyEvent (utils.Digeste ) returns(KeyEvent_) {}
+    rpc getKeyEventCoords (stereotomy.EventCoords) returns(KeyEvent_) {}
+    rpc getKeyState (stereotomy.Ident) returns (stereotomy.KeyState_) {}
+    rpc getKeyStateCoords (stereotomy.EventCoords) returns (stereotomy.KeyState_) {}
+    rpc getKeyStateWithAttachments (stereotomy.EventCoords) returns (stereotomy.KeyStateWithAttachments_) {}
+    rpc getKeyStateWithEndorsementsAndValidations (stereotomy.EventCoords) returns (stereotomy.KeyStateWithEndorsementsAndValidations_) {}
+    rpc getKERL (stereotomy.Ident) returns (stereotomy.KERL_) {}
+    rpc getValidations (stereotomy.EventCoords) returns (stereotomy.Validations) {}
 }
 
 service EventObserver { 
@@ -106,13 +69,13 @@ service EventObserver {
 
 // Binding API for Resolver
 service Binder {
-    rpc bind(BindContext) returns(google.protobuf.Empty) {}
-    rpc unbind(IdentifierContext) returns(google.protobuf.Empty) {}
+    rpc bind(stereotomy.Binding ) returns(google.protobuf.Empty) {}
+    rpc unbind(stereotomy.Ident) returns(google.protobuf.Empty) {}
 }
 
 // Resolver API
 service Resolver {
-    rpc lookup (IdentifierContext) returns (stereotomy.Binding) {}
+    rpc lookup (stereotomy.Ident) returns (stereotomy.Binding) {}
 }
 
 // Validator API

--- a/grpc/src/main/proto/thoth.proto
+++ b/grpc/src/main/proto/thoth.proto
@@ -18,16 +18,16 @@ service KerlDht {
     rpc appendKERL (stereotomy.services.KERLContext) returns (stereotomy.services.KeyStates) {}
     rpc appendWithAttachments (stereotomy.services.KeyEventWithAttachmentsContext) returns (stereotomy.services.KeyStates) {}
     rpc appendAttachments (stereotomy.services.AttachmentsContext) returns (google.protobuf.Empty) {}
-    rpc appendValidations (stereotomy.services.ValidationsContext) returns (google.protobuf.Empty) {}
+    rpc appendValidations (stereotomy.Validations) returns (google.protobuf.Empty) {}
     
-    rpc getAttachment (stereotomy.services.EventContext) returns (stereotomy.Attachment) {}
-    rpc getKeyEventCoords (stereotomy.services.EventContext) returns (stereotomy.KeyEvent_) {}
-    rpc getKeyState (stereotomy.services.IdentifierContext) returns (stereotomy.KeyState_) {}
-    rpc getKeyStateCoords (stereotomy.services.EventContext) returns (stereotomy.KeyState_) {}
-    rpc getKeyStateWithAttachments (stereotomy.services.EventContext) returns (stereotomy.KeyStateWithAttachments_) {}
-    rpc getKeyStateWithEndorsementsAndValidations (stereotomy.services.EventContext) returns (stereotomy.KeyStateWithEndorsementsAndValidations_) {}
-    rpc getKERL (stereotomy.services.IdentifierContext) returns (stereotomy.KERL_) {}
-    rpc getValidations (stereotomy.services.EventContext) returns (stereotomy.Validations) {}
+    rpc getAttachment (stereotomy.EventCoords) returns (stereotomy.Attachment) {}
+    rpc getKeyEventCoords (stereotomy.EventCoords) returns (stereotomy.KeyEvent_) {}
+    rpc getKeyState (stereotomy.Ident) returns (stereotomy.KeyState_) {}
+    rpc getKeyStateCoords (stereotomy.EventCoords) returns (stereotomy.KeyState_) {}
+    rpc getKeyStateWithAttachments (stereotomy.EventCoords) returns (stereotomy.KeyStateWithAttachments_) {}
+    rpc getKeyStateWithEndorsementsAndValidations (stereotomy.EventCoords) returns (stereotomy.KeyStateWithEndorsementsAndValidations_) {}
+    rpc getKERL (stereotomy.Ident) returns (stereotomy.KERL_) {}
+    rpc getValidations (stereotomy.EventCoords) returns (stereotomy.Validations) {}
 }
 
 service Delegated {

--- a/grpc/src/main/proto/thoth.proto
+++ b/grpc/src/main/proto/thoth.proto
@@ -47,22 +47,15 @@ message Update {
 }
 
 message Updating {
-    utils.Digeste context = 1;
-    int32 ring = 2;
-    repeated stereotomy.KeyEvent_ events = 3; 
+    int32 ring = 1;
+    repeated stereotomy.KeyEvent_ events = 2; 
 }
 
-message Intervals {
-    utils.Digeste context = 1;
-    int32 ring = 2;
-    repeated Interval intervals = 3;
-    utils.Biff have = 4;
-} 
-
-message Get {
-    utils.Digeste context = 1;
-    utils.Digeste identifier = 2;
-} 
+message Intervals { 
+    int32 ring = 1;
+    repeated Interval intervals = 2;
+    utils.Biff have = 3;
+}
 
 message Interval {
     utils.Digeste start = 1;

--- a/memberships/src/main/java/com/salesforce/apollo/membership/messaging/rbc/ReliableBroadcaster.java
+++ b/memberships/src/main/java/com/salesforce/apollo/membership/messaging/rbc/ReliableBroadcaster.java
@@ -494,7 +494,6 @@ public class ReliableBroadcaster {
                   ring);
         try {
             return link.gossip(MessageBff.newBuilder()
-                                         .setContext(context.getId().toDigeste())
                                          .setRing(ring)
                                          .setDigests(buffer.forReconcilliation().toBff())
                                          .build());
@@ -529,7 +528,6 @@ public class ReliableBroadcaster {
             destination.link()
                        .update(ReconcileContext.newBuilder()
                                                .setRing(destination.ring())
-                                               .setContext(context.getId().toDigeste())
                                                .addAllUpdates(buffer.reconcile(BloomFilter.from(gossip.getDigests()),
                                                                                destination.member().getId()))
                                                .build());

--- a/stereotomy-services/src/main/java/com/salesforce/apollo/stereotomy/services/grpc/binder/BinderClient.java
+++ b/stereotomy-services/src/main/java/com/salesforce/apollo/stereotomy/services/grpc/binder/BinderClient.java
@@ -13,14 +13,10 @@ import com.codahale.metrics.Timer.Context;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.protobuf.Empty;
 import com.salesfoce.apollo.stereotomy.event.proto.Ident;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.BindContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.BinderGrpc;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.BinderGrpc.BinderFutureStub;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.IdentifierContext;
-import com.salesfoce.apollo.utils.proto.Digeste;
 import com.salesforce.apollo.archipelago.ManagedServerChannel;
 import com.salesforce.apollo.archipelago.ServerConnectionCache.CreateClientCommunications;
-import com.salesforce.apollo.crypto.Digest;
 import com.salesforce.apollo.membership.Member;
 import com.salesforce.apollo.stereotomy.services.grpc.StereotomyMetrics;
 
@@ -30,20 +26,18 @@ import com.salesforce.apollo.stereotomy.services.grpc.StereotomyMetrics;
  */
 public class BinderClient implements BinderService {
 
-    public static CreateClientCommunications<BinderService> getCreate(Digest context, StereotomyMetrics metrics) {
+    public static CreateClientCommunications<BinderService> getCreate(StereotomyMetrics metrics) {
         return (c) -> {
-            return new BinderClient(context, c, metrics);
+            return new BinderClient(c, metrics);
         };
 
     }
 
     private final ManagedServerChannel channel;
     private final BinderFutureStub     client;
-    private final Digeste              context;
     private final StereotomyMetrics    metrics;
 
-    public BinderClient(Digest context, ManagedServerChannel channel, StereotomyMetrics metrics) {
-        this.context = context.toDigeste();
+    public BinderClient(ManagedServerChannel channel, StereotomyMetrics metrics) {
         this.channel = channel;
         this.client = BinderGrpc.newFutureStub(channel).withCompression("gzip");
         this.metrics = metrics;
@@ -52,13 +46,12 @@ public class BinderClient implements BinderService {
     @Override
     public CompletableFuture<Boolean> bind(com.salesfoce.apollo.stereotomy.event.proto.Binding binding) {
         Context timer = metrics == null ? null : metrics.bindClient().time();
-        var request = BindContext.newBuilder().setContext(context).setBinding(binding).build();
         if (metrics != null) {
-            metrics.outboundBandwidth().mark(request.getSerializedSize());
-            metrics.outboundBindRequest().mark(request.getSerializedSize());
+            metrics.outboundBandwidth().mark(binding.getSerializedSize());
+            metrics.outboundBindRequest().mark(binding.getSerializedSize());
         }
         CompletableFuture<Boolean> f = new CompletableFuture<>();
-        ListenableFuture<Empty> result = client.bind(request);
+        ListenableFuture<Empty> result = client.bind(binding);
         result.addListener(() -> {
             try {
                 result.get();
@@ -90,13 +83,12 @@ public class BinderClient implements BinderService {
     @Override
     public CompletableFuture<Boolean> unbind(Ident identifier) {
         Context timer = metrics == null ? null : metrics.unbindClient().time();
-        var request = IdentifierContext.newBuilder().setIdentifier(identifier).setContext(context).build();
         if (metrics != null) {
-            metrics.outboundBandwidth().mark(request.getSerializedSize());
-            metrics.outboundUnbindRequest().mark(request.getSerializedSize());
+            metrics.outboundBandwidth().mark(identifier.getSerializedSize());
+            metrics.outboundUnbindRequest().mark(identifier.getSerializedSize());
         }
         CompletableFuture<Boolean> f = new CompletableFuture<>();
-        ListenableFuture<Empty> result = client.unbind(request);
+        ListenableFuture<Empty> result = client.unbind(identifier);
         result.addListener(() -> {
             try {
                 result.get();

--- a/stereotomy-services/src/main/java/com/salesforce/apollo/stereotomy/services/grpc/binder/BinderServer.java
+++ b/stereotomy-services/src/main/java/com/salesforce/apollo/stereotomy/services/grpc/binder/BinderServer.java
@@ -8,9 +8,9 @@ package com.salesforce.apollo.stereotomy.services.grpc.binder;
 
 import com.codahale.metrics.Timer.Context;
 import com.google.protobuf.Empty;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.BindContext;
+import com.salesfoce.apollo.stereotomy.event.proto.Binding;
+import com.salesfoce.apollo.stereotomy.event.proto.Ident;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.BinderGrpc.BinderImplBase;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.IdentifierContext;
 import com.salesforce.apollo.archipelago.RoutableService;
 import com.salesforce.apollo.crypto.Digest;
 import com.salesforce.apollo.protocols.ClientIdentity;
@@ -36,7 +36,7 @@ public class BinderServer extends BinderImplBase {
     }
 
     @Override
-    public void bind(BindContext request, StreamObserver<Empty> responseObserver) {
+    public void bind(Binding request, StreamObserver<Empty> responseObserver) {
         Context timer = metrics != null ? metrics.bindService().time() : null;
         if (metrics != null) {
             metrics.inboundBandwidth().mark(request.getSerializedSize());
@@ -48,7 +48,7 @@ public class BinderServer extends BinderImplBase {
             return;
         }
         routing.evaluate(responseObserver, s -> {
-            var result = s.bind(request.getBinding());
+            var result = s.bind(request);
             result.whenComplete((b, t) -> {
                 if (timer != null) {
                     timer.stop();
@@ -64,7 +64,7 @@ public class BinderServer extends BinderImplBase {
     }
 
     @Override
-    public void unbind(IdentifierContext request, StreamObserver<Empty> responseObserver) {
+    public void unbind(Ident request, StreamObserver<Empty> responseObserver) {
         Context timer = metrics != null ? metrics.unbindService().time() : null;
         if (metrics != null) {
             metrics.inboundBandwidth().mark(request.getSerializedSize());
@@ -76,7 +76,7 @@ public class BinderServer extends BinderImplBase {
             return;
         }
         routing.evaluate(responseObserver, s -> {
-            var result = s.unbind(request.getIdentifier());
+            var result = s.unbind(request);
             result.whenComplete((b, t) -> {
                 if (timer != null) {
                     timer.stop();

--- a/stereotomy-services/src/main/java/com/salesforce/apollo/stereotomy/services/grpc/kerl/KERLServer.java
+++ b/stereotomy-services/src/main/java/com/salesforce/apollo/stereotomy/services/grpc/kerl/KERLServer.java
@@ -12,20 +12,19 @@ import java.util.concurrent.CompletableFuture;
 import com.codahale.metrics.Timer.Context;
 import com.google.protobuf.Empty;
 import com.salesfoce.apollo.stereotomy.event.proto.Attachment;
+import com.salesfoce.apollo.stereotomy.event.proto.EventCoords;
+import com.salesfoce.apollo.stereotomy.event.proto.Ident;
 import com.salesfoce.apollo.stereotomy.event.proto.KERL_;
 import com.salesfoce.apollo.stereotomy.event.proto.KeyEvent_;
 import com.salesfoce.apollo.stereotomy.event.proto.KeyStateWithAttachments_;
 import com.salesfoce.apollo.stereotomy.event.proto.KeyState_;
 import com.salesfoce.apollo.stereotomy.event.proto.Validations;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.AttachmentsContext;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.EventContext;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.IdentifierContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KERLContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KERLServiceGrpc.KERLServiceImplBase;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KeyEventWithAttachmentsContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KeyEventsContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KeyStates;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.ValidationsContext;
 import com.salesforce.apollo.archipelago.RoutableService;
 import com.salesforce.apollo.stereotomy.services.grpc.StereotomyMetrics;
 import com.salesforce.apollo.stereotomy.services.proto.ProtoKERLService;
@@ -144,14 +143,14 @@ public class KERLServer extends KERLServiceImplBase {
     }
 
     @Override
-    public void appendValidations(ValidationsContext request, StreamObserver<Empty> responseObserver) {
+    public void appendValidations(Validations request, StreamObserver<Empty> responseObserver) {
         Context timer = metrics != null ? metrics.appendEventsService().time() : null;
         if (metrics != null) {
             metrics.inboundBandwidth().mark(request.getSerializedSize());
             metrics.inboundAppendEventsRequest().mark(request.getSerializedSize());
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<Empty> result = s.appendValidations(request.getValidations());
+            CompletableFuture<Empty> result = s.appendValidations(request);
             if (result == null) {
                 responseObserver.onNext(Empty.getDefaultInstance());
                 responseObserver.onCompleted();
@@ -208,7 +207,7 @@ public class KERLServer extends KERLServiceImplBase {
     }
 
     @Override
-    public void getAttachment(EventContext request, StreamObserver<Attachment> responseObserver) {
+    public void getAttachment(EventCoords request, StreamObserver<Attachment> responseObserver) {
         Context timer = metrics != null ? metrics.getAttachmentService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -216,7 +215,7 @@ public class KERLServer extends KERLServiceImplBase {
             metrics.inboundGetAttachmentRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<Attachment> response = s.getAttachment(request.getCoordinates());
+            CompletableFuture<Attachment> response = s.getAttachment(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -246,7 +245,7 @@ public class KERLServer extends KERLServiceImplBase {
     }
 
     @Override
-    public void getKERL(IdentifierContext request, StreamObserver<KERL_> responseObserver) {
+    public void getKERL(Ident request, StreamObserver<KERL_> responseObserver) {
         Context timer = metrics != null ? metrics.getKERLService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -254,7 +253,7 @@ public class KERLServer extends KERLServiceImplBase {
             metrics.inboundGetKERLRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KERL_> response = s.getKERL(request.getIdentifier());
+            CompletableFuture<KERL_> response = s.getKERL(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -284,14 +283,14 @@ public class KERLServer extends KERLServiceImplBase {
     }
 
     @Override
-    public void getKeyEventCoords(EventContext request, StreamObserver<KeyEvent_> responseObserver) {
+    public void getKeyEventCoords(EventCoords request, StreamObserver<KeyEvent_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyEventCoordsService().time() : null;
         if (metrics != null) {
             metrics.inboundBandwidth().mark(request.getSerializedSize());
             metrics.inboundGetKeyEventCoordsRequest().mark(request.getSerializedSize());
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyEvent_> response = s.getKeyEvent(request.getCoordinates());
+            CompletableFuture<KeyEvent_> response = s.getKeyEvent(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -321,7 +320,7 @@ public class KERLServer extends KERLServiceImplBase {
     }
 
     @Override
-    public void getKeyState(IdentifierContext request, StreamObserver<KeyState_> responseObserver) {
+    public void getKeyState(Ident request, StreamObserver<KeyState_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyStateService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -329,7 +328,7 @@ public class KERLServer extends KERLServiceImplBase {
             metrics.inboundGetKeyStateRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyState_> response = s.getKeyState(request.getIdentifier());
+            CompletableFuture<KeyState_> response = s.getKeyState(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -358,7 +357,7 @@ public class KERLServer extends KERLServiceImplBase {
     }
 
     @Override
-    public void getKeyStateCoords(EventContext request, StreamObserver<KeyState_> responseObserver) {
+    public void getKeyStateCoords(EventCoords request, StreamObserver<KeyState_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyStateCoordsService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -366,7 +365,7 @@ public class KERLServer extends KERLServiceImplBase {
             metrics.inboundGetKeyStateCoordsRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyState_> response = s.getKeyState(request.getCoordinates());
+            CompletableFuture<KeyState_> response = s.getKeyState(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -395,7 +394,7 @@ public class KERLServer extends KERLServiceImplBase {
     }
 
     @Override
-    public void getKeyStateWithAttachments(EventContext request,
+    public void getKeyStateWithAttachments(EventCoords request,
                                            StreamObserver<KeyStateWithAttachments_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyStateService().time() : null;
         if (metrics != null) {
@@ -404,7 +403,7 @@ public class KERLServer extends KERLServiceImplBase {
             metrics.inboundGetKeyStateRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyStateWithAttachments_> response = s.getKeyStateWithAttachments(request.getCoordinates());
+            CompletableFuture<KeyStateWithAttachments_> response = s.getKeyStateWithAttachments(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -433,7 +432,7 @@ public class KERLServer extends KERLServiceImplBase {
     }
 
     @Override
-    public void getValidations(EventContext request, StreamObserver<Validations> responseObserver) {
+    public void getValidations(EventCoords request, StreamObserver<Validations> responseObserver) {
         Context timer = metrics != null ? metrics.getAttachmentService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -441,7 +440,7 @@ public class KERLServer extends KERLServiceImplBase {
             metrics.inboundGetAttachmentRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<Validations> response = s.getValidations(request.getCoordinates());
+            CompletableFuture<Validations> response = s.getValidations(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();

--- a/stereotomy-services/src/main/java/com/salesforce/apollo/stereotomy/services/grpc/resolver/ResolverServer.java
+++ b/stereotomy-services/src/main/java/com/salesforce/apollo/stereotomy/services/grpc/resolver/ResolverServer.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 import com.codahale.metrics.Timer.Context;
 import com.salesfoce.apollo.stereotomy.event.proto.Binding;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.IdentifierContext;
+import com.salesfoce.apollo.stereotomy.event.proto.Ident;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.ResolverGrpc.ResolverImplBase;
 import com.salesforce.apollo.archipelago.RoutableService;
 import com.salesforce.apollo.stereotomy.services.grpc.StereotomyMetrics;
@@ -33,14 +33,14 @@ public class ResolverServer extends ResolverImplBase {
     }
 
     @Override
-    public void lookup(IdentifierContext request, StreamObserver<Binding> responseObserver) {
+    public void lookup(Ident request, StreamObserver<Binding> responseObserver) {
         Context timer = metrics != null ? metrics.lookupService().time() : null;
         if (metrics != null) {
             metrics.inboundBandwidth().mark(request.getSerializedSize());
             metrics.inboundLookupRequest().mark(request.getSerializedSize());
         }
         routing.evaluate(responseObserver, s -> {
-            Optional<Binding> response = s.lookup(request.getIdentifier());
+            Optional<Binding> response = s.lookup(request);
             if (response.isEmpty()) {
                 if (timer != null) {
                     timer.stop();

--- a/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestBinder.java
+++ b/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestBinder.java
@@ -100,8 +100,7 @@ public class TestBinder {
                             r -> new BinderServer(r, ci, null), null, null);
 
         var clientComms = clientRouter.create(clientMember, context, protoService, protoService.getClass().toString(),
-                                              r -> new BinderServer(r, ci, null), BinderClient.getCreate(context, null),
-                                              null);
+                                              r -> new BinderServer(r, ci, null), BinderClient.getCreate(null), null);
 
         var client = clientComms.connect(serverMember);
 

--- a/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestEventObserver.java
+++ b/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestEventObserver.java
@@ -106,7 +106,7 @@ public class TestEventObserver {
 
         var clientComms = clientRouter.create(clientMember, context, protoService, protoService.getClass().toString(),
                                               r -> new EventObserverServer(r, identity, null),
-                                              EventObserverClient.getCreate(context, null), null);
+                                              EventObserverClient.getCreate(null), null);
 
         var client = clientComms.connect(serverMember);
 

--- a/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestEventValidation.java
+++ b/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestEventValidation.java
@@ -85,7 +85,7 @@ public class TestEventValidation {
 
         var clientComms = clientRouter.create(clientMember, context, protoService, protoService.getClass().toString(),
                                               r -> new EventValidationServer(r, null),
-                                              EventValidationClient.getCreate(context, null), null);
+                                              EventValidationClient.getCreate(null), null);
 
         var client = clientComms.connect(serverMember);
 

--- a/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestKerlService.java
+++ b/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestKerlService.java
@@ -140,7 +140,7 @@ public class TestKerlService {
 
         var clientComms = clientRouter.create(clientMember, context, protoService,
                                               protoService.getClass().getCanonicalName(), r -> new KERLServer(r, null),
-                                              KERLClient.getCreate(context, null), null);
+                                              KERLClient.getCreate(null), null);
 
         var client = clientComms.connect(serverMember);
         return client;

--- a/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestResolver.java
+++ b/stereotomy-services/src/test/java/com/salesforce/apollo/stereotomy/services/grpc/TestResolver.java
@@ -83,8 +83,7 @@ public class TestResolver {
                             r -> new ResolverServer(r, null), null, null);
 
         var clientComms = clientRouter.create(clientMember, context, protoService, protoService.getClass().toString(),
-                                              r -> new ResolverServer(r, null), ResolverClient.getCreate(context, null),
-                                              null);
+                                              r -> new ResolverServer(r, null), ResolverClient.getCreate(null), null);
 
         var client = clientComms.connect(serverMember);
 

--- a/thoth/src/main/java/com/salesforce/apollo/thoth/KerlDHT.java
+++ b/thoth/src/main/java/com/salesforce/apollo/thoth/KerlDHT.java
@@ -873,7 +873,6 @@ public class KerlDHT implements ProtoKERLService {
         log.trace("Interval reconciliation on ring: {} with: {} on: {} intervals: {}", ring, link.getMember(),
                   member.getId(), keyIntervals);
         return link.reconcile(Intervals.newBuilder()
-                                       .setContext(context.getId().toDigeste())
                                        .setRing(ring)
                                        .addAllIntervals(keyIntervals.toIntervals())
                                        .setHave(populate(keyIntervals))

--- a/thoth/src/main/java/com/salesforce/apollo/thoth/KerlDHT.java
+++ b/thoth/src/main/java/com/salesforce/apollo/thoth/KerlDHT.java
@@ -282,7 +282,7 @@ public class KerlDHT implements ProtoKERLService {
         this.frequency = frequency;
         this.scheduler = scheduler;
         dhtComms = communications.create(member, context.getId(), service, service.getClass().getCanonicalName(),
-                                         r -> new DhtServer(r, metrics), DhtClient.getCreate(context.getId(), metrics),
+                                         r -> new DhtServer(r, metrics), DhtClient.getCreate(metrics),
                                          DhtClient.getLocalLoopback(service, member));
         reconcileComms = communications.create(member, context.getId(), reconciliation,
                                                reconciliation.getClass().getCanonicalName(),

--- a/thoth/src/main/java/com/salesforce/apollo/thoth/grpc/dht/DhtServer.java
+++ b/thoth/src/main/java/com/salesforce/apollo/thoth/grpc/dht/DhtServer.java
@@ -12,6 +12,8 @@ import java.util.concurrent.CompletableFuture;
 import com.codahale.metrics.Timer.Context;
 import com.google.protobuf.Empty;
 import com.salesfoce.apollo.stereotomy.event.proto.Attachment;
+import com.salesfoce.apollo.stereotomy.event.proto.EventCoords;
+import com.salesfoce.apollo.stereotomy.event.proto.Ident;
 import com.salesfoce.apollo.stereotomy.event.proto.KERL_;
 import com.salesfoce.apollo.stereotomy.event.proto.KeyEvent_;
 import com.salesfoce.apollo.stereotomy.event.proto.KeyStateWithAttachments_;
@@ -19,13 +21,10 @@ import com.salesfoce.apollo.stereotomy.event.proto.KeyStateWithEndorsementsAndVa
 import com.salesfoce.apollo.stereotomy.event.proto.KeyState_;
 import com.salesfoce.apollo.stereotomy.event.proto.Validations;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.AttachmentsContext;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.EventContext;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.IdentifierContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KERLContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KeyEventWithAttachmentsContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KeyEventsContext;
 import com.salesfoce.apollo.stereotomy.services.grpc.proto.KeyStates;
-import com.salesfoce.apollo.stereotomy.services.grpc.proto.ValidationsContext;
 import com.salesfoce.apollo.thoth.proto.KerlDhtGrpc.KerlDhtImplBase;
 import com.salesforce.apollo.archipelago.RoutableService;
 import com.salesforce.apollo.stereotomy.services.grpc.StereotomyMetrics;
@@ -144,14 +143,14 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void appendValidations(ValidationsContext request, StreamObserver<Empty> responseObserver) {
+    public void appendValidations(Validations request, StreamObserver<Empty> responseObserver) {
         Context timer = metrics != null ? metrics.appendWithAttachmentsService().time() : null;
         if (metrics != null) {
             metrics.inboundBandwidth().mark(request.getSerializedSize());
             metrics.inboundAppendWithAttachmentsRequest().mark(request.getSerializedSize());
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<Empty> result = s.appendValidations(request.getValidations());
+            CompletableFuture<Empty> result = s.appendValidations(request);
             if (result == null) {
                 responseObserver.onError(new StatusRuntimeException(Status.DATA_LOSS));
             } else {
@@ -208,7 +207,7 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void getAttachment(EventContext request, StreamObserver<Attachment> responseObserver) {
+    public void getAttachment(EventCoords request, StreamObserver<Attachment> responseObserver) {
         Context timer = metrics != null ? metrics.getAttachmentService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -216,7 +215,7 @@ public class DhtServer extends KerlDhtImplBase {
             metrics.inboundGetAttachmentRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<Attachment> response = s.getAttachment(request.getCoordinates());
+            CompletableFuture<Attachment> response = s.getAttachment(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -246,7 +245,7 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void getKERL(IdentifierContext request, StreamObserver<KERL_> responseObserver) {
+    public void getKERL(Ident request, StreamObserver<KERL_> responseObserver) {
         Context timer = metrics != null ? metrics.getKERLService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -254,7 +253,7 @@ public class DhtServer extends KerlDhtImplBase {
             metrics.inboundGetKERLRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KERL_> response = s.getKERL(request.getIdentifier());
+            CompletableFuture<KERL_> response = s.getKERL(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -284,14 +283,14 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void getKeyEventCoords(EventContext request, StreamObserver<KeyEvent_> responseObserver) {
+    public void getKeyEventCoords(EventCoords request, StreamObserver<KeyEvent_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyEventCoordsService().time() : null;
         if (metrics != null) {
             metrics.inboundBandwidth().mark(request.getSerializedSize());
             metrics.inboundGetKeyEventCoordsRequest().mark(request.getSerializedSize());
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyEvent_> response = s.getKeyEvent(request.getCoordinates());
+            CompletableFuture<KeyEvent_> response = s.getKeyEvent(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -321,7 +320,7 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void getKeyState(IdentifierContext request, StreamObserver<KeyState_> responseObserver) {
+    public void getKeyState(Ident request, StreamObserver<KeyState_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyStateService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -329,7 +328,7 @@ public class DhtServer extends KerlDhtImplBase {
             metrics.inboundGetKeyStateRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyState_> response = s.getKeyState(request.getIdentifier());
+            CompletableFuture<KeyState_> response = s.getKeyState(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -358,7 +357,7 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void getKeyStateCoords(EventContext request, StreamObserver<KeyState_> responseObserver) {
+    public void getKeyStateCoords(EventCoords request, StreamObserver<KeyState_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyStateCoordsService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -366,7 +365,7 @@ public class DhtServer extends KerlDhtImplBase {
             metrics.inboundGetKeyStateCoordsRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyState_> response = s.getKeyState(request.getCoordinates());
+            CompletableFuture<KeyState_> response = s.getKeyState(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -395,7 +394,7 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void getKeyStateWithAttachments(EventContext request,
+    public void getKeyStateWithAttachments(EventCoords request,
                                            StreamObserver<KeyStateWithAttachments_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyStateCoordsService().time() : null;
         if (metrics != null) {
@@ -404,7 +403,7 @@ public class DhtServer extends KerlDhtImplBase {
             metrics.inboundGetKeyStateCoordsRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyStateWithAttachments_> response = s.getKeyStateWithAttachments(request.getCoordinates());
+            CompletableFuture<KeyStateWithAttachments_> response = s.getKeyStateWithAttachments(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -433,7 +432,7 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void getKeyStateWithEndorsementsAndValidations(EventContext request,
+    public void getKeyStateWithEndorsementsAndValidations(EventCoords request,
                                                           StreamObserver<KeyStateWithEndorsementsAndValidations_> responseObserver) {
         Context timer = metrics != null ? metrics.getKeyStateCoordsService().time() : null;
         if (metrics != null) {
@@ -442,7 +441,7 @@ public class DhtServer extends KerlDhtImplBase {
             metrics.inboundGetKeyStateCoordsRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<KeyStateWithEndorsementsAndValidations_> response = s.getKeyStateWithEndorsementsAndValidations(request.getCoordinates());
+            CompletableFuture<KeyStateWithEndorsementsAndValidations_> response = s.getKeyStateWithEndorsementsAndValidations(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();
@@ -471,7 +470,7 @@ public class DhtServer extends KerlDhtImplBase {
     }
 
     @Override
-    public void getValidations(EventContext request, StreamObserver<Validations> responseObserver) {
+    public void getValidations(EventCoords request, StreamObserver<Validations> responseObserver) {
         Context timer = metrics != null ? metrics.getAttachmentService().time() : null;
         if (metrics != null) {
             final var serializedSize = request.getSerializedSize();
@@ -479,7 +478,7 @@ public class DhtServer extends KerlDhtImplBase {
             metrics.inboundGetAttachmentRequest().mark(serializedSize);
         }
         routing.evaluate(responseObserver, s -> {
-            CompletableFuture<Validations> response = s.getValidations(request.getCoordinates());
+            CompletableFuture<Validations> response = s.getValidations(request);
             if (response == null) {
                 if (timer != null) {
                     timer.stop();


### PR DESCRIPTION
Clean up RPCs, removing explicit Context Digest for routing, as this is no implicit in the Archipelago refactoring of basic comms