### PR TITLE
CHOAM combine RBC opti

### DIFF
--- a/choam/src/main/java/com/salesforce/apollo/choam/CHOAM.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/CHOAM.java
@@ -981,16 +981,19 @@ public class CHOAM {
                  params.member().getId());
         for (int i = 0; i < execs.size(); i++) {
             var exec = execs.get(i);
+            final var index = i;
             Digest hash = hashOf(exec, params.digestAlgorithm());
             var stxn = session.complete(hash);
-            try {
-                params.processor()
-                      .execute(i, CHOAM.hashOf(exec, params.digestAlgorithm()), exec,
-                               stxn == null ? null : stxn.onCompletion());
-            } catch (Throwable t) {
-                log.error("Exception processing transaction: {} block: {} height: {} on: {}", hash, h.hash, h.height(),
-                          params.member().getId());
-            }
+            executions.execute(() -> {
+                try {
+                    params.processor()
+                          .execute(index, CHOAM.hashOf(exec, params.digestAlgorithm()), exec,
+                                   stxn == null ? null : stxn.onCompletion());
+                } catch (Throwable t) {
+                    log.error("Exception processing transaction: {} block: {} height: {} on: {}", hash, h.hash,
+                              h.height(), params.member().getId());
+                }
+            });
         }
     }
 

--- a/choam/src/main/java/com/salesforce/apollo/choam/CHOAM.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/CHOAM.java
@@ -915,7 +915,7 @@ public class CHOAM {
     private void combine(Msg m) {
         CertifiedBlock block;
         try {
-            block = CertifiedBlock.parseFrom(m.content());
+            block = m.content().unpack(CertifiedBlock.class);
         } catch (InvalidProtocolBufferException e) {
             log.debug("unable to parse block content from {} on: {}", m.source(), params.member().getId());
             return;

--- a/choam/src/main/java/com/salesforce/apollo/choam/CHOAM.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/CHOAM.java
@@ -680,7 +680,9 @@ public class CHOAM {
         nextView();
         combine = new ReliableBroadcaster(params.context(), params.member(), params.combine(), params.exec(),
                                           params.communications(),
-                                          params.metrics() == null ? null : params.metrics().getCombineMetrics());
+                                          params.metrics() == null ? null : params.metrics().getCombineMetrics(),
+                                          ReliableBroadcaster.defaultMessageAuth(params.context(),
+                                                                                 params.digestAlgorithm()));
         linear = Executors.newSingleThreadExecutor(Utils.virtualThreadFactory("Linear " + params.member().getId()));
         combine.registerHandler((ctx, messages) -> {
             try {

--- a/choam/src/main/java/com/salesforce/apollo/choam/Parameters.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/Parameters.java
@@ -268,7 +268,7 @@ public record Parameters(Parameters.RuntimeParameters runtime, ReliableBroadcast
             private Supplier<KERL_>                                kerl         = () -> KERL_.getDefaultInstance();
             private SigningMember                                  member;
             private ChoamMetrics                                   metrics;
-            private TransactionExecutor                            processor    = (i, h, t, f) -> {
+            private TransactionExecutor                            processor    = (i, h, t, f, exec) -> {
                                                                                 };
             private BiConsumer<HashedBlock, CheckpointState>       restorer     = (height, checkpointState) -> {
                                                                                 };

--- a/choam/src/main/java/com/salesforce/apollo/choam/Producer.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/Producer.java
@@ -66,9 +66,6 @@ public class Producer {
 
         @Override
         public void assembled() {
-            if (!reconfigured.compareAndSet(false, true)) {
-                return;
-            }
             final var slate = assembly.get().getSlate();
             var reconfiguration = new HashedBlock(params().digestAlgorithm(),
                                                   view.reconfigure(slate, nextViewId, previousBlock.get(),
@@ -185,7 +182,6 @@ public class Producer {
     private final Map<Digest, PendingBlock>         pending            = new ConcurrentHashMap<>();
     private final BlockingQueue<Reassemble>         pendingReassembles = new LinkedBlockingQueue<>();
     private final AtomicReference<HashedBlock>      previousBlock      = new AtomicReference<>();
-    private final AtomicBoolean                     reconfigured       = new AtomicBoolean();
     private final AtomicBoolean                     started            = new AtomicBoolean(false);
     private final Transitions                       transitions;
     private final ViewContext                       view;

--- a/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitServer.java
+++ b/choam/src/main/java/com/salesforce/apollo/choam/comm/TxnSubmitServer.java
@@ -40,15 +40,13 @@ public class TxnSubmitServer extends TransactionSubmissionImplBase {
             responseObserver.onError(new IllegalStateException("Member has been removed"));
             return;
         }
-        router.evaluate(responseObserver,
-
-                        s -> {
-                            try {
-                                responseObserver.onNext(s.submit(request, from));
-                                responseObserver.onCompleted();
-                            } catch (StatusRuntimeException e) {
-                                responseObserver.onError(e);
-                            }
-                        });
+        router.evaluate(responseObserver, s -> {
+            try {
+                responseObserver.onNext(s.submit(request, from));
+                responseObserver.onCompleted();
+            } catch (StatusRuntimeException e) {
+                responseObserver.onError(e);
+            }
+        });
     }
 }

--- a/choam/src/test/java/com/salesforce/apollo/choam/MembershipTests.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/MembershipTests.java
@@ -16,6 +16,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -187,9 +188,9 @@ public class MembershipTests {
 
                 @SuppressWarnings({ "unchecked", "rawtypes" })
                 @Override
-                public void execute(int index, Digest hash, Transaction t, CompletableFuture f) {
+                public void execute(int index, Digest hash, Transaction t, CompletableFuture f, Executor executor) {
                     if (f != null) {
-                        f.complete(new Object());
+                        f.completeAsync(() -> new Object(), executor);
                     }
                 }
             };

--- a/choam/src/test/java/com/salesforce/apollo/choam/MembershipTests.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/MembershipTests.java
@@ -87,8 +87,6 @@ public class MembershipTests {
               .forEach(ch -> ch.getValue().start());
 
         final Duration timeout = Duration.ofSeconds(6);
-        final var scheduler = Executors.newScheduledThreadPool(1);
-
         var txneer = choams.get(members.get(0).getId());
 
         System.out.println("Transactioneer: " + txneer.getId());
@@ -112,8 +110,10 @@ public class MembershipTests {
                            .toList());
 
         final var countdown = new CountDownLatch(1);
-        var transactioneer = new Transactioneer(txneer.getSession(), Executors.newSingleThreadExecutor(), timeout, 1,
-                                                scheduler, countdown, Executors.newSingleThreadExecutor());
+        var transactioneer = new Transactioneer(txneer.getSession(), timeout, 1,
+                                                Executors.newScheduledThreadPool(1, Utils.virtualThreadFactory()),
+                                                countdown,
+                                                Executors.newSingleThreadExecutor(Utils.virtualThreadFactory()));
 
         transactioneer.start();
         assertTrue(countdown.await(30, TimeUnit.SECONDS), "Could not submit transaction");

--- a/choam/src/test/java/com/salesforce/apollo/choam/SessionTest.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/SessionTest.java
@@ -76,10 +76,6 @@ public class SessionTest {
         Function<SubmittedTransaction, SubmitResult> service = stx -> {
             ForkJoinPool.commonPool().execute(() -> {
                 try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                }
-                try {
                     stx.onCompletion()
                        .complete(ByteMessage.parseFrom(stx.transaction().getContent()).getContents().toStringUtf8());
                 } catch (InvalidProtocolBufferException e) {

--- a/choam/src/test/java/com/salesforce/apollo/choam/SessionTest.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/SessionTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
@@ -72,9 +73,15 @@ public class SessionTest {
                                                                                                                            entropy).newIdentifier()
                                                                                                                                    .get()))
                                                               .build());
+        var gate = new CountDownLatch(1);
         @SuppressWarnings("unchecked")
         Function<SubmittedTransaction, SubmitResult> service = stx -> {
             ForkJoinPool.commonPool().execute(() -> {
+                try {
+                    gate.await();
+                } catch (InterruptedException e) {
+                    throw new IllegalStateException(e);
+                }
                 try {
                     stx.onCompletion()
                        .complete(ByteMessage.parseFrom(stx.transaction().getContent()).getContents().toStringUtf8());
@@ -89,6 +96,7 @@ public class SessionTest {
         Message tx = ByteMessage.newBuilder().setContents(ByteString.copyFromUtf8(content)).build();
         var result = session.submit(tx, null, exec);
         assertEquals(1, session.submitted());
+        gate.countDown();
         assertEquals(content, result.get(1, TimeUnit.SECONDS));
         assertEquals(0, session.submitted());
     }

--- a/choam/src/test/java/com/salesforce/apollo/choam/TestCHOAM.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/TestCHOAM.java
@@ -137,9 +137,9 @@ public class TestCHOAM {
 
                 @SuppressWarnings({ "unchecked", "rawtypes" })
                 @Override
-                public void execute(int index, Digest hash, Transaction t, CompletableFuture f) {
+                public void execute(int index, Digest hash, Transaction t, CompletableFuture f, Executor executor) {
                     if (f != null) {
-                        f.complete(new Object());
+                        f.completeAsync(() -> new Object(), executor);
                     }
                 }
             };

--- a/choam/src/test/java/com/salesforce/apollo/choam/Transactioneer.java
+++ b/choam/src/test/java/com/salesforce/apollo/choam/Transactioneer.java
@@ -40,18 +40,16 @@ class Transactioneer {
     private final ByteMessage                tx        = ByteMessage.newBuilder()
                                                                     .setContents(ByteString.copyFromUtf8("Give me food or give me slack or kill me"))
                                                                     .build();
-    private final Executor                   txnCompletion;
     private final Executor                   txnExecutor;
 
-    Transactioneer(Session session, Executor txnCompletion, Duration timeout, int max,
-                   ScheduledExecutorService scheduler, CountDownLatch countdown, Executor txnScheduler) {
+    Transactioneer(Session session, Duration timeout, int max, ScheduledExecutorService scheduler,
+                   CountDownLatch countdown, Executor txnScheduler) {
         this.session = session;
         this.timeout = timeout;
         this.max = max;
         this.scheduler = scheduler;
         this.countdown = countdown;
         this.txnExecutor = txnScheduler;
-        this.txnCompletion = txnCompletion;
     }
 
     public int getCompleted() {
@@ -89,7 +87,7 @@ class Transactioneer {
                     }, log));
                 }
             }
-        }, txnCompletion));
+        }, txnExecutor));
         inFlight.add(futureSailor.get());
     }
 

--- a/grpc/src/main/proto/messaging.proto
+++ b/grpc/src/main/proto/messaging.proto
@@ -5,6 +5,7 @@ option java_package = "com.salesfoce.apollo.messaging.proto";
 option java_outer_classname = "MessagingProto";
 option objc_class_prefix = "Mp";
 import "google/protobuf/empty.proto";
+import "google/protobuf/any.proto";
 import "util.proto";
 
 package messaging;
@@ -35,13 +36,13 @@ message ReconcileContext {
 
 message AgedMessage {
     int32 age = 1;
-    bytes content = 3;
+    google.protobuf.Any content = 3;
 }
 
 message DefaultMessage {
     utils.Digeste source = 1;
     int32 nonce = 2;
-    bytes content = 3;
+    google.protobuf.Any content = 3;
 }
 
 message SignedDefaultMessage {

--- a/grpc/src/main/proto/messaging.proto
+++ b/grpc/src/main/proto/messaging.proto
@@ -7,9 +7,9 @@ option objc_class_prefix = "Mp";
 import "google/protobuf/empty.proto";
 import "util.proto";
 
-package messaging; 
+package messaging;
 
-message MessageBff { 
+message MessageBff {
     int32 ring = 1;
     utils.Biff digests = 2;
 }
@@ -23,20 +23,28 @@ service RBC {
     rpc update (ReconcileContext) returns (google.protobuf.Empty) {}
 }
 
-message Reconcile { 
+message Reconcile {
     repeated  AgedMessage updates = 1;
     utils.Biff digests = 2;
 }
 
-message ReconcileContext { 
+message ReconcileContext {
     int32 ring = 1;
     repeated  AgedMessage updates = 2;
 }
 
 message AgedMessage {
     int32 age = 1;
+    bytes content = 3;
+}
+
+message DefaultMessage {
+    utils.Digeste source = 1;
     int32 nonce = 2;
     bytes content = 3;
-    utils.Digeste source = 4;
-    utils.Sig signature = 5;
+}
+
+message SignedDefaultMessage {
+    DefaultMessage content = 1;
+    utils.Sig signature = 2;
 }

--- a/memberships/src/test/java/com/salesforce/apollo/membership/messaging/RbcTest.java
+++ b/memberships/src/test/java/com/salesforce/apollo/membership/messaging/RbcTest.java
@@ -151,7 +151,7 @@ public class RbcTest {
 
         var exec = Executors.newVirtualThreadPerTaskExecutor();
         final var prefix = UUID.randomUUID().toString();
-        final var authentication = ReliableBroadcaster.defaultMessageAuth(context, DigestAlgorithm.DEFAULT);
+        final var authentication = ReliableBroadcaster.defaultMessageAdapter(context, DigestAlgorithm.DEFAULT);
         messengers = members.stream().map(node -> {
             var comms = new LocalServer(prefix, node, exec).router(
                                                                    ServerConnectionCache.newBuilder()

--- a/sql-state/.gitignore
+++ b/sql-state/.gitignore
@@ -1,0 +1,1 @@
+/sql-state-log.txt

--- a/sql-state/src/main/java/com/salesforce/apollo/state/Emulator.java
+++ b/sql-state/src/main/java/com/salesforce/apollo/state/Emulator.java
@@ -101,7 +101,8 @@ public class Emulator {
             lock.lock();
             try {
                 Transaction txn = st.transaction();
-                txnExec.execute(txnIndex.incrementAndGet(), CHOAM.hashOf(txn, algorithm), txn, st.onCompletion());
+                txnExec.execute(txnIndex.incrementAndGet(), CHOAM.hashOf(txn, algorithm), txn, st.onCompletion(),
+                                r -> r.run());
                 return SubmitResult.newBuilder().setResult(Result.PUBLISHED).build();
             } finally {
                 lock.unlock();

--- a/sql-state/src/main/java/com/salesforce/apollo/state/SqlStateMachine.java
+++ b/sql-state/src/main/java/com/salesforce/apollo/state/SqlStateMachine.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -195,7 +196,7 @@ public class SqlStateMachine {
 
         @Override
         public void execute(int index, Digest txnHash, Transaction tx,
-                            @SuppressWarnings("rawtypes") CompletableFuture onComplete) {
+                            @SuppressWarnings("rawtypes") CompletableFuture onComplete, Executor executor) {
             boolean closed;
             try {
                 closed = connection().isClosed();
@@ -214,7 +215,7 @@ public class SqlStateMachine {
                 return;
             }
             withContext(() -> {
-                SqlStateMachine.this.execute(index, txnHash, txn, onComplete);
+                SqlStateMachine.this.execute(index, txnHash, txn, onComplete, executor);
             });
 
         }
@@ -228,7 +229,7 @@ public class SqlStateMachine {
             });
             int i = 0;
             for (Transaction txn : initialization) {
-                execute(i, Digest.NONE, txn, null);
+                execute(i, Digest.NONE, txn, null, r -> r.run());
             }
             log.debug("Genesis executed on: {}", url);
         }
@@ -789,11 +790,12 @@ public class SqlStateMachine {
     }
 
     @SuppressWarnings("unchecked")
-    private void complete(@SuppressWarnings("rawtypes") CompletableFuture onCompletion, Object results) {
+    private void complete(@SuppressWarnings("rawtypes") CompletableFuture onCompletion, Object results,
+                          Executor executor) {
         if (onCompletion == null) {
             return;
         }
-        onCompletion.complete(results);
+        onCompletion.completeAsync(() -> results, executor);
     }
 
     private void dropAll(Drop drop) throws LiquibaseException {
@@ -823,7 +825,7 @@ public class SqlStateMachine {
     }
 
     private void execute(int index, Digest txnHash, Txn tx,
-                         @SuppressWarnings("rawtypes") CompletableFuture onCompletion) {
+                         @SuppressWarnings("rawtypes") CompletableFuture onCompletion, Executor executor) {
         log.debug("executing: {}", tx.getExecutionCase());
         var executing = executingBlock.get();
         updateCurrent(executing.height, executing.blkHash, index, txnHash);
@@ -841,7 +843,7 @@ public class SqlStateMachine {
             case MIGRATION -> acceptMigration(tx.getMigration());
             default -> null;
             };
-            this.complete(onCompletion, results);
+            this.complete(onCompletion, results, executor);
         } catch (JdbcSQLNonTransientConnectionException e) {
             // ignore
         } catch (Exception e) {

--- a/sql-state/src/main/java/com/salesforce/apollo/state/SqlStateMachine.java
+++ b/sql-state/src/main/java/com/salesforce/apollo/state/SqlStateMachine.java
@@ -902,16 +902,18 @@ public class SqlStateMachine {
 
     private void publishEvents() {
         try (ResultSet events = getEvents.executeQuery()) {
-            while (events.next()) {
-                String channel = events.getString(2);
-                JsonNode body;
-                try {
-                    body = MAPPER.readTree(events.getString(3));
-                } catch (JsonProcessingException e) {
-                    log.warn("cannot deserialize event: {} channel: {}", events.getInt(1), channel, e);
-                    continue;
+            if (events != null) {
+                while (events.next()) {
+                    String channel = events.getString(2);
+                    JsonNode body;
+                    try {
+                        body = MAPPER.readTree(events.getString(3));
+                    } catch (JsonProcessingException e) {
+                        log.warn("cannot deserialize event: {} channel: {}", events.getInt(1), channel, e);
+                        continue;
+                    }
+                    trampoline.publish(new Event(channel, body));
                 }
-                trampoline.publish(new Event(channel, body));
             }
         } catch (JdbcSQLNonTransientException | JdbcSQLNonTransientConnectionException e) {
         } catch (SQLException e) {

--- a/sql-state/src/test/java/com/salesforce/apollo/state/AbstractLifecycleTest.java
+++ b/sql-state/src/test/java/com/salesforce/apollo/state/AbstractLifecycleTest.java
@@ -403,8 +403,8 @@ abstract public class AbstractLifecycleTest {
 
             @Override
             public void execute(int i, Digest hash, Transaction tx,
-                                @SuppressWarnings("rawtypes") CompletableFuture onComplete) {
-                up.getExecutor().execute(i, hash, tx, onComplete);
+                                @SuppressWarnings("rawtypes") CompletableFuture onComplete, Executor executor) {
+                up.getExecutor().execute(i, hash, tx, onComplete, executor);
             }
 
             @Override

--- a/sql-state/src/test/java/com/salesforce/apollo/state/CHOAMTest.java
+++ b/sql-state/src/test/java/com/salesforce/apollo/state/CHOAMTest.java
@@ -335,8 +335,10 @@ public class CHOAMTest {
 
                                                            @Override
                                                            public void execute(int i, Digest hash, Transaction tx,
-                                                                               @SuppressWarnings("rawtypes") CompletableFuture onComplete) {
-                                                               up.getExecutor().execute(i, hash, tx, onComplete);
+                                                                               @SuppressWarnings("rawtypes") CompletableFuture onComplete,
+                                                                               Executor executor) {
+                                                               up.getExecutor()
+                                                                 .execute(i, hash, tx, onComplete, executor);
                                                            }
 
                                                            @Override

--- a/sql-state/src/test/java/com/salesforce/apollo/state/CHOAMTest.java
+++ b/sql-state/src/test/java/com/salesforce/apollo/state/CHOAMTest.java
@@ -102,7 +102,6 @@ public class CHOAMTest {
     private File                baseDir;
     private File                checkpointDirBase;
     private Map<Digest, CHOAM>  choams;
-    private Executor            exec = Executors.newVirtualThreadPerTaskExecutor();
     private List<SigningMember> members;
     private MetricRegistry      registry;
     private Map<Digest, Router> routers;
@@ -134,6 +133,7 @@ public class CHOAMTest {
 
     @BeforeEach
     public void before() throws Exception {
+        var exec = Executors.newVirtualThreadPerTaskExecutor();
         registry = new MetricRegistry();
         checkpointDirBase = new File("target/ct-chkpoints-" + Entropy.nextBitsStreamLong());
         Utils.clean(checkpointDirBase);
@@ -175,12 +175,13 @@ public class CHOAMTest {
         }));
         choams = members.stream().collect(Collectors.toMap(m -> m.getId(), m -> {
             return createCHOAM(entropy, params, m, context, metrics,
-                               Executors.newScheduledThreadPool(2, Thread.ofVirtual().factory()));
+                               Executors.newScheduledThreadPool(5, Thread.ofVirtual().factory()), exec);
         }));
     }
 
     @Test
     public void submitMultiplTxn() throws Exception {
+        var exec = Executors.newVirtualThreadPerTaskExecutor();
         final Random entropy = new Random();
         final Duration timeout = Duration.ofSeconds(12);
         var transactioneers = new ArrayList<Transactioneer>();
@@ -205,7 +206,7 @@ public class CHOAMTest {
             for (int i = 0; i < clientCount; i++) {
                 transactioneers.add(new Transactioneer(() -> update(entropy, mutator), mutator, timeout, max, exec,
                                                        countdown,
-                                                       Executors.newScheduledThreadPool(1,
+                                                       Executors.newScheduledThreadPool(5,
                                                                                         Thread.ofVirtual().factory())));
             }
         });
@@ -303,7 +304,7 @@ public class CHOAMTest {
     }
 
     private CHOAM createCHOAM(Random entropy, Builder params, SigningMember m, Context<Member> context,
-                              ChoamMetrics metrics, ScheduledExecutorService scheduler) {
+                              ChoamMetrics metrics, ScheduledExecutorService scheduler, Executor exec) {
         String url = String.format("jdbc:h2:mem:test_engine-%s-%s", m.getId(), entropy.nextLong());
         System.out.println("DB URL: " + url);
         SqlStateMachine up = new SqlStateMachine(url, new Properties(),

--- a/sql-state/src/test/java/com/salesforce/apollo/state/MutatorTest.java
+++ b/sql-state/src/test/java/com/salesforce/apollo/state/MutatorTest.java
@@ -61,7 +61,7 @@ public class MutatorTest {
                          Transaction.newBuilder()
                                     .setContent(Txn.newBuilder().setMigration(migration).build().toByteString())
                                     .build(),
-                         success);
+                         success, r -> r.run());
 
         success.get(1, TimeUnit.SECONDS);
 
@@ -71,7 +71,7 @@ public class MutatorTest {
                          Transaction.newBuilder()
                                     .setContent(Txn.newBuilder().setMigration(migration).build().toByteString())
                                     .build(),
-                         success);
+                         success, r -> r.run());
 
         success.get(1, TimeUnit.SECONDS);
 
@@ -95,7 +95,7 @@ public class MutatorTest {
                          Transaction.newBuilder()
                                     .setContent(Txn.newBuilder().setCall(call).build().toByteString())
                                     .build(),
-                         success);
+                         success, r -> r.run());
 
         CallResult result = (CallResult) success.get(1, TimeUnit.SECONDS);
         assertNotNull(result);
@@ -112,7 +112,7 @@ public class MutatorTest {
                          Transaction.newBuilder()
                                     .setContent(Txn.newBuilder().setBatched(batch.build()).build().toByteString())
                                     .build(),
-                         success);
+                         success, r -> r.run());
 
         var batchResult = (List<?>) success.get(1, TimeUnit.SECONDS);
         assertNotNull(batchResult);

--- a/sql-state/src/test/java/com/salesforce/apollo/state/ScriptTest.java
+++ b/sql-state/src/test/java/com/salesforce/apollo/state/ScriptTest.java
@@ -47,7 +47,8 @@ public class ScriptTest {
                      .build();
         CompletableFuture<Object> completion = new CompletableFuture<>();
         machine.getExecutor()
-               .execute(0, Digest.NONE, Transaction.newBuilder().setContent(txn.toByteString()).build(), completion);
+               .execute(0, Digest.NONE, Transaction.newBuilder().setContent(txn.toByteString()).build(), completion,
+                        r -> r.run());
 
         assertTrue(ResultSet.class.isAssignableFrom(completion.get().getClass()));
         ResultSet rs = (ResultSet) completion.get();

--- a/sql-state/src/test/resources/logback-test.xml
+++ b/sql-state/src/test/resources/logback-test.xml
@@ -13,6 +13,16 @@
         </encoder>
     </appender>
 
+    <!--
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>sql-state-log.txt </file>
+        <append>false</append>
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+    -->
+
     <logger name="org.jooq.Constants" level="warn" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
@@ -27,33 +37,9 @@
 
     <logger name="liquibase" level="warn" additivity="false">
         <appender-ref ref="STDOUT" />
-    </logger> 
-
-    <logger name="com.salesforce.apollo.state" level="info" additivity="false">
-        <appender-ref ref="STDOUT" />
     </logger>
 
     <logger name="com.salesforce.apollo.choam" level="info" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
-
-    <logger name="com.salesforce.apollo.choam.support.Bootstrapper" level="info" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
- 
-    <logger name="com.salesforce.apollo.choam.support" level="info" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
-
-    <logger name="com.salesforce.apollo.choam.Session" level="info" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
-
-    <logger name="com.salesforce.apollo.choam.Producer" level="info" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
-
-    <logger name="com.salesforce.apollo.choam.GenesisAssembly" level="info" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 
@@ -61,15 +47,7 @@
         <appender-ref ref="STDOUT" />
     </logger>
 
-    <logger name="com.salesforce.apollo.ethereal" level="info" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
-
-    <logger name="com.salesforce.apollo.ethereal.memberships" level="info" additivity="false">
-        <appender-ref ref="STDOUT" />
-    </logger>
-
-    <logger name="com.salesforce.apollo.state" level="info" additivity="false">
+    <logger name="com.salesforce.apollo.choam.Session" level="warn" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 

--- a/utils/src/main/java/com/salesforce/apollo/utils/Utils.java
+++ b/utils/src/main/java/com/salesforce/apollo/utils/Utils.java
@@ -55,7 +55,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.locks.Lock;
@@ -743,7 +743,7 @@ public class Utils {
         }
     }
 
-    public static Executor newVirtualThreadPerTaskExecutor() {
+    public static ExecutorService newVirtualThreadPerTaskExecutor() {
         return Executors.newVirtualThreadPerTaskExecutor();
     }
 


### PR DESCRIPTION
Fix async bug introduced by using the CHOAM txn executor to defer txn execution.  Replace this with passing txn executor and async completing the local pending completableFuture with the result.

Optimize the RBC so that CHOAM can now efficiently publish Blocks.  RBC no longer imposes structure on the messages passed, how they are verified and how the hash is calculated.  This allows the CHOAM Publisher to emit blocks that are congruent with other published blocks carrying int the same certifiers.